### PR TITLE
Import Table at the package level

### DIFF
--- a/quivr/__init__.py
+++ b/quivr/__init__.py
@@ -34,9 +34,10 @@ from .fields import (
 )
 from .indexing import StringIndex
 from .matrix import MatrixArray, MatrixExtensionType
+from .tables import Table
 
 __all__ = [
-    "TableBase",
+    "Table",
     "MatrixArray",
     "MatrixExtensionType",
     "concatenate",


### PR DESCRIPTION
Makes Table importable as:
```python
from quivr import Table
```

Feel free to close if you have a local fix already. 