### PR TITLE
Check attributes and subtable attributes for equality in Tables.__eq__

### DIFF
--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -568,10 +568,22 @@ class Table:
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Table):
-            return bool(self.table.equals(other.table))
+            table_eq = bool(self.table.equals(other.table))
         if isinstance(other, pa.Table):
-            return bool(self.table.equals(other))
-        return False
+            table_eq = bool(self.table.equals(other))
+
+        # Check if the attributes are the same
+        attr_eq = self.attributes() == other.attributes()
+        
+        # Now check if the subtables are the same (these tables
+        # too may have attributes)
+        subtables = self._quivr_subtables
+        other_subtables = other._quivr_subtables
+        subtable_eq = subtables.keys() == other_subtables.keys()
+        for name in subtables.keys():
+            subtable_eq = subtable_eq and getattr(self, name) == getattr(other, name)
+
+        return table_eq and attr_eq and subtable_eq
 
     def take(self, row_indices: Union[list[int], pa.IntegerArray]) -> Self:
         """Return a new Table with only the rows at the given indices."""

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -568,22 +568,10 @@ class Table:
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Table):
-            table_eq = bool(self.table.equals(other.table))
+            return bool(self.table.equals(other.table, check_metadata=True))
         if isinstance(other, pa.Table):
-            table_eq = bool(self.table.equals(other))
-
-        # Check if the attributes are the same
-        attr_eq = self.attributes() == other.attributes()
-        
-        # Now check if the subtables are the same (these tables
-        # too may have attributes)
-        subtables = self._quivr_subtables
-        other_subtables = other._quivr_subtables
-        subtable_eq = subtables.keys() == other_subtables.keys()
-        for name in subtables.keys():
-            subtable_eq = subtable_eq and getattr(self, name) == getattr(other, name)
-
-        return table_eq and attr_eq and subtable_eq
+            return bool(self.table.equals(other, check_metadata=True))
+        return False
 
     def take(self, row_indices: Union[list[int], pa.IntegerArray]) -> Self:
         """Return a new Table with only the rows at the given indices."""

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from quivr.attributes import StringAttribute
+from quivr.attributes import StringAttribute, IntAttribute
 from quivr.columns import DictionaryColumn, Int8Column, Int64Column, StringColumn
 from quivr.concat import concatenate
 from quivr.errors import ValidationError
@@ -29,6 +29,69 @@ class Pair(Table):
 class Wrapper(Table):
     pair = Pair.as_column()
     id = StringColumn()
+
+
+def test_table__eq__():
+
+    class A(Table):
+        x = Int64Column()
+        y = StringAttribute()
+
+    class B(Table):
+        z = Int64Column()
+        a = A.as_column()
+        b = IntAttribute()
+    
+    a_table = A.from_kwargs(
+        x=[1],
+        y="y",
+    )
+    a_table_same = A.from_kwargs(
+        x=[1],
+        y="y",
+    )
+    a_table_attr_diff = A.from_kwargs(
+        x=[1],
+        y="z",
+    )
+    a_table_col_diff = A.from_kwargs(
+        x=[0],
+        y="y",
+    )
+    a_table_attr_col_diff = A.from_kwargs(
+        x=[0],
+        y="z",
+    )
+
+    assert a_table == a_table
+    assert a_table == a_table_same
+    assert a_table != a_table_attr_diff
+    assert a_table != a_table_col_diff
+    assert a_table != a_table_attr_col_diff
+
+    b_table = B.from_kwargs(
+        z=[1],
+        a=a_table,
+        b=1,
+    )
+    b_table_same = B.from_kwargs(
+        z=[1],
+        a=a_table,
+        b=1,
+    )
+    b_table_subattr_diff = B.from_kwargs(
+        z=[1],
+        a=a_table_attr_diff,
+        b=1,
+    )
+    b_table_attr_diff = B.from_kwargs(
+        z=[1],
+        a=a_table,
+        b=2,
+    )
+    assert b_table == b_table_same
+    assert b_table != b_table_subattr_diff
+    assert b_table != b_table_attr_diff
 
 
 def test_create_from_arrays():

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from quivr.attributes import StringAttribute, IntAttribute
+from quivr.attributes import IntAttribute, StringAttribute
 from quivr.columns import DictionaryColumn, Int8Column, Int64Column, StringColumn
 from quivr.concat import concatenate
 from quivr.errors import ValidationError
@@ -32,7 +32,6 @@ class Wrapper(Table):
 
 
 def test_table__eq__():
-
     class A(Table):
         x = Int64Column()
         y = StringAttribute()
@@ -41,7 +40,7 @@ def test_table__eq__():
         z = Int64Column()
         a = A.as_column()
         b = IntAttribute()
-    
+
     a_table = A.from_kwargs(
         x=[1],
         y="y",
@@ -552,3 +551,41 @@ class TestValidation:
         table = MyTable.from_data(x=[8, 9, 10], validate=False)
         with pytest.raises(ValidationError):
             table.validate()
+
+
+class TestTableEqualityBenchmarks:
+    @pytest.mark.benchmark(group="table-equality")
+    def test_identical_small_tables(self, benchmark):
+        table1 = TableWithAttributes.from_kwargs(x=[1, 2, 3], y=[4, 5, 6], attrib="foo")
+        table2 = TableWithAttributes.from_kwargs(x=[1, 2, 3], y=[4, 5, 6], attrib="foo")
+        benchmark(table1.__eq__, table2)
+
+    @pytest.mark.benchmark(group="table-equality")
+    def test_identical_large_tables(self, benchmark):
+        table1 = TableWithAttributes.from_kwargs(x=np.arange(10000), y=np.arange(10000), attrib="foo")
+        table2 = TableWithAttributes.from_kwargs(x=np.arange(10000), y=np.arange(10000), attrib="foo")
+        benchmark(table1.__eq__, table2)
+
+    @pytest.mark.benchmark(group="table-equality")
+    def test_different_small_tables(self, benchmark):
+        table1 = TableWithAttributes.from_kwargs(x=[1, 2, 3], y=[4, 5, 6], attrib="foo")
+        table2 = TableWithAttributes.from_kwargs(x=[1, 2, 3], y=[4, 5, 7], attrib="foo")
+        benchmark(table1.__eq__, table2)
+
+    @pytest.mark.benchmark(group="table-equality")
+    def test_different_large_tables(self, benchmark):
+        table1 = TableWithAttributes.from_kwargs(x=np.arange(10000), y=np.arange(10000), attrib="foo")
+        table2 = TableWithAttributes.from_kwargs(x=np.arange(10000), y=np.arange(10000) + 1, attrib="foo")
+        benchmark(table1.__eq__, table2)
+
+    @pytest.mark.benchmark(group="table-equality")
+    def test_small_tables_different_attributes(self, benchmark):
+        table1 = TableWithAttributes.from_kwargs(x=[1, 2, 3], y=[4, 5, 6], attrib="foo")
+        table2 = TableWithAttributes.from_kwargs(x=[1, 2, 3], y=[4, 5, 6], attrib="bar")
+        benchmark(table1.__eq__, table2)
+
+    @pytest.mark.benchmark(group="table-equality")
+    def test_large_tables_different_attributes(self, benchmark):
+        table1 = TableWithAttributes.from_kwargs(x=np.arange(10000), y=np.arange(10000), attrib="foo")
+        table2 = TableWithAttributes.from_kwargs(x=np.arange(10000), y=np.arange(10000), attrib="bar")
+        benchmark(table1.__eq__, table2)


### PR DESCRIPTION
Here is a trial implementation for attribute checks (Tables already had `__eq__` defined, took me an embarrassingly long time to realize my definition of `__eq__` was being overridden by a pre-existing one haha). 

I suspect you might want to edit the control flow a bit. 