### PR TITLE
Pure python Linkages

### DIFF
--- a/docs/source/api/linkages.rst
+++ b/docs/source/api/linkages.rst
@@ -1,0 +1,21 @@
+Linkages
+========
+
+.. currentmodule:: quivr
+
+Linkages are tools for building relationships that span multiple tables.
+
+You can use linkages to act as indexes to relate the rows from two
+different tables which share common values. In fact, linkages are a
+bit more general than that: they can relate rows based on computed
+values as well.
+
+.. autoclass:: Linkage
+   :members:
+
+.. autoclass:: MultiKeyLinkage
+   :members:
+
+.. autodata:: quivr.linkage.LeftTable
+
+.. autodata:: quivr.linkage.RightTable

--- a/docs/source/api/linkages.rst
+++ b/docs/source/api/linkages.rst
@@ -16,6 +16,6 @@ values as well.
 .. autoclass:: MultiKeyLinkage
    :members:
 
-.. autodata:: quivr.linkage.LeftTable
+.. autotypevar:: quivr.linkage.LeftTable
 
-.. autodata:: quivr.linkage.RightTable
+.. autotypevar:: quivr.linkage.RightTable

--- a/docs/source/api/overview.rst
+++ b/docs/source/api/overview.rst
@@ -17,7 +17,9 @@ Table of Contents
    columns
    column_validators
    attributes
+   linkages
    errors
+
    
 .. module:: quivr
 
@@ -29,6 +31,7 @@ Primary API Objects
 
    Table
    Column
+   Linkage
 
 Column Types
 ------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,8 +36,9 @@ exclude_patterns = []
 autodoc_type_aliases = {
     "MetadataDict": "MetadataDict",
     "quivr.MetadataDict": "MetadataDict",
-    "quivr.columns.MetadataDict": "MetadataDict",        
+    "quivr.columns.MetadataDict": "MetadataDict",
 }
+
 autodoc_member_order = 'bysource'
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -1,0 +1,7 @@
+Examples
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   linkage

--- a/docs/source/examples/linkage.rst
+++ b/docs/source/examples/linkage.rst
@@ -1,0 +1,154 @@
+.. _linkage-example:
+
+Linkages Example
+================
+
+Let's imagine we have two tables: one is a table of people, and the
+other is a table of their pets. The people table has a unique
+identifier for each person, and the pets table has a column that
+contains the identifier of the person who owns the pet.
+
+
+.. literalinclude:: ./linkages.py
+   :language: python
+   :lines: 1-11
+
+For example:
+
++-----------------------------------+
+|**Owners**                         |
++----------+------------+-----------+
+|       id |       name |       age |
++==========+============+===========+
+|    1     |    Bob     |    30     |
++----------+------------+-----------+
+|    2     |    Sue     |    25     |
++----------+------------+-----------+
+|    3     |    Joe     |    40     |
++----------+------------+-----------+
+|    4     |    Mary    |    35     |
++----------+------------+-----------+
+|    5     |    John    |    50     |
++----------+------------+-----------+
+
++----------------------------------------------------+
+| **Pets**                                           |
++-----------+----------+---------------+-------------+
+|     name  | owner_id |     owner_id  |     species |
++===========+==========+===============+=============+
+|   Fido    |    1     |       1       |    Dog      |
++-----------+----------+---------------+-------------+
+|   Spot    |    1     |       1       |    Dog      |
++-----------+----------+---------------+-------------+
+| Mittens   |    2     |       2       |    Cat      |
++-----------+----------+---------------+-------------+
+|  Rover    |    3     |       3       |    Dog      |
++-----------+----------+---------------+-------------+
+|   Lucy    |    4     |       4       |    Dog      |
++-----------+----------+---------------+-------------+
+| Whiskers  |    5     |       5       |    Cat      |
++-----------+----------+---------------+-------------+
+|   Max     |    5     |       5       |    Dog      |
++-----------+----------+---------------+-------------+
+
+       
+Let's suppose we want to get the average age of people who own a
+particular species of pet.
+
+The problem linkages solve
+--------------------------
+
+One way without linkages would be to construct a new table that
+merges the two tables together:
+
+.. literalinclude:: ./linkages.py
+   :language: python
+   :lines: 15-17
+
+But this table is inefficient: it contains extra copies of the owner
+information, and it includes columns we won't use like the owner's
+name. It also requires us to duplicate the owner information for each
+pet they own.
+
+Take a look:
+
++----------+------------+-----------+----------+---------------+-------------+
+| owner.id | owner.name | owner.age | pet.name | pet.owner_id  | pet.species |
++==========+============+===========+==========+===============+=============+
+|    1     |    Bob     |    30     |   Fido   |       1       |    Dog      |
++----------+------------+-----------+----------+---------------+-------------+
+|    1     |    Bob     |    30     |   Spot   |       1       |    Dog      |
++----------+------------+-----------+----------+---------------+-------------+
+|    2     |    Sue     |    25     | Mittens  |       2       |    Cat      |
++----------+------------+-----------+----------+---------------+-------------+
+|    3     |    Joe     |    40     |  Rover   |       3       |    Dog      |
++----------+------------+-----------+----------+---------------+-------------+
+|    4     |    Mary    |    35     |   Lucy   |       4       |    Dog      |
++----------+------------+-----------+----------+---------------+-------------+
+|    5     |    John    |    50     | Whiskers |       5       |    Cat      |
++----------+------------+-----------+----------+---------------+-------------+
+|    5     |    John    |    50     |   Max    |       5       |    Dog      |
++----------+------------+-----------+----------+---------------+-------------+
+
+
+Building a Linkage
+------------------
+
+Instead, we'd like to link the two tables together. We can do this by using :obj:`quivr.Linkage`:
+
+.. literalinclude:: ./linkages.py
+   :language: python
+   :lines: 21-33
+
+Using the linkage
+-----------------
+
+The linkage has two main methods: :obj:`quivr.Linkage.select` and
+:obj:`quivr.Linkage.iterate`. These methods are also aliased for
+ergonomics: you can use ``linkage[...]`` to select rows, and ``for row
+in linkage`` to iterate over rows.
+
+Let's select the info associated with the person with ID=1:
+
+.. literalinclude:: ./linkages.py
+   :language: python
+   :lines: 37-46
+
+We can also iterate over all the groups in the linkage. This yields
+out tuples of ``(id, owner, pets)`` in our case. In general, it yields
+the ``(key, left_table, right_table)`` for each unique ``key`` found
+in the two tables.
+
+.. literalinclude:: ./linkages.py
+   :language: python
+   :lines: 50-56
+
+One thing to notice here is that **linkages are unsorted**. The order
+that the keys were provided does not necessarily correspond to the
+order of the rows yielded from the linkage.
+
+Using the linkage in computation
+--------------------------------
+
+Let's put this together to compute the average age of people who own
+cats and dogs:
+
+.. literalinclude:: ./linkages.py
+   :language: python
+   :lines: 60-74
+
+There are a few things to note here.
+
+1. Iteration yields ``Table`` instances. Each group is a table that
+   contains the rows from the left and right tables that match the
+   key. In this case, the left table is the ``owners`` table, and the
+   right table is the ``pets`` table.
+
+2. The ``Table`` instances are **views** into the original tables. No
+   data is copied. This makes linkages very efficient.
+
+3. Combining across multiple groups is handled with
+   :obj:`quivr.concatenate`. This utility function takes a list of
+   tables and concatenates them together.
+
+

--- a/docs/source/examples/linkages.py
+++ b/docs/source/examples/linkages.py
@@ -1,0 +1,76 @@
+from quivr import Table, StringColumn, UInt32Column, Linkage, concatenate
+
+class People(Table):
+    id = UInt32Column()
+    name = StringColumn()
+    age = UInt32Column()
+
+class Pets(Table):
+    name = StringColumn()
+    owner_id = UInt32Column()
+    species = StringColumn()
+
+# L13
+
+class PetsAndOwners(Table):
+    owner = People.as_column()
+    pets = Pets.as_column()
+
+# L19
+
+people = People.from_data(
+    id=[1, 2, 3, 4, 5],
+    name=['Bob', 'Sue', 'Joe', 'Mary', 'John'],
+    age=[30, 25, 40, 35, 50]
+)
+
+pets = Pets.from_data(
+    name=['Fido', 'Spot', 'Mittens', 'Rover', 'Lucy', 'Whiskers', 'Max'],
+    owner_id=[1, 1, 2, 3, 4, 5, 5],
+    species=['Dog', 'Dog', 'Cat', 'Dog', 'Dog', 'Cat', 'Dog']
+)
+
+linkage = Linkage(people, pets, people.id, pets.owner_id)
+
+# L35
+
+person, pets = linkage.select(1)
+print(person.name)
+# [
+#  "Bob"
+# ]
+print(pets.name)
+# [
+#  "Fido",
+#  "Spot"
+# ]
+
+# L48
+
+for id, owner, pets in linkage:
+    print(f"{owner.name[0]} has {len(pets)} pets")
+# Mary has 1 pets
+# John has 2 pets
+# Bob has 2 pets
+# Sue has 1 pets
+# Joe has 1 pets
+
+# L58
+
+cat_owners = []
+dog_owners = []
+for id, owner, pets in linkage:
+    if 'Cat' in pets.species.tolist():
+        cat_owners.append(owner)
+    if 'Dog' in pets.species.tolist():
+        dog_owners.append(owner)
+
+cat_owners = concatenate(cat_owners)
+dog_owners = concatenate(dog_owners)
+
+print(cat_owners.age.to_numpy().mean())
+# 37.5
+print(dog_owners.age.to_numpy().mean())
+# 38.75
+
+# L76

--- a/docs/source/guides/cross-table-links.rst
+++ b/docs/source/guides/cross-table-links.rst
@@ -1,0 +1,121 @@
+Linkages: Working with Multiple Tables
+======================================
+
+.. currentmodule:: quivr
+		   
+.. note::
+
+   See also: :ref:`linkage-example` for a worked example of using
+   linkages.
+
+It is common with tabular data to have relationships between different
+tables. :obj:`quivr.Linkage` provides a mechanism for representing
+these relationships in a compact and efficient way.
+
+Linkages can represent one-to-one, many-to-one, or many-to-many
+relationships. They're most efficient in the one-to-one scenario, but
+all types of relations work.
+
+Creating Linkages
+-----------------
+
+Linkages are created by using the :obj:`quivr.Linkage`
+constructor. You must pass in two tables, termed the "left" and
+"right" tables, and two :obj:`pyarrow.Array`\ s of keys ("left_keys"
+and "right_keys") that specify how the tables are related.
+
+It's worth emphasizing that the key arrays do not need to directly be
+columns on the tables. They could be computed from column data, or
+even be arbitrary data.
+
+But there are some **requirements of the keys**:
+
+1. The left keys need to be the same length as the left
+   table. Likewise, the right keys must be the same length as the
+   right table.
+2. There must not be any nulls in the left keys or the right keys.
+3. The key arrays must be identically typed (e.g. both ``uint8``, both
+   ``int32``, both ``string``, etc.)
+
+There are some things that are *not* requirements which should be
+pointed out explicitly:
+
+- The keys don't need to be unique. If there are multiple rows with
+  the same key, then the linkage will return all of them.
+- The keys don't need to be sorted.
+- The left and right keys don't need to contain the same values. If
+  they're entirely different, then linkages will only return results
+  for the side that has a matching key.
+
+
+Operations on Linkages
+----------------------
+
+Once you have a linkage, you get four basic operations:
+
+1. :obj:`Linkage.select` - Select rows from both tables that match a
+   given key.
+2. :obj:`Linkage.iterate` - Iterate over all the unique keys across
+   both tables, yielding the key along with the matching rows from the
+   left and right tables.
+3. :obj:`Linkage.select_left` - Select rows from the left table that
+   match a given key.
+4. :obj:`Linkage.select_right` - Select rows from the right table that
+   match a given key.
+
+Each of these methods returns :obj:`Table` objects directly, which are
+built as sliced views of the original underlying data. This means that
+they're very efficient, and don't require any copying of data.
+
+Since the data inside of Tables are immutable, you can't modify the
+results of these operations. But you can use them as inputs to other
+operations, or write them to disk, or whatever else you want to do
+with them.
+
+If a key is entirely absent from one of the tables, you'll get an
+empty table (as produced with :meth:`Table.empty`).
+
+In addition, linkages keep references to their original tables and
+keys. You can access them with the ``Linkage.left_table``,
+``Linkage.right_table``, ``Linkage.left_keys``, and
+``Linkage.right_keys`` attributes.
+
+Sorted Iteration
+----------------
+
+Linkages are not sorted, but you can iterate over them in sorted order
+by using the original key arrays.
+
+For example, if you have a linkage ``lnk`` and you want to iterate
+over it in order of increasing ID, you can do this:
+
+.. code-block:: python
+
+   import pyarrow as pa
+   keys = pa.concat_arrays([lnk.left_keys, lnk.right_keys]).unique().sort()
+   for k in keys:
+       left, right = lnk.select(k)
+       # do something with the left and right tables
+
+
+
+Linking on multiple arrays
+--------------------------
+
+Linkages can be created on multiple arrays of data. See the
+:obj:`MultiKeyLinkage` documentation for thorough details.
+
+The basic idea is that instead of providing left and right key arrays,
+you provide dictionaries of key arrays. The keys of the dictionaries
+are used to identify the arrays, and the values are the arrays
+themselves.
+
+The dictionaries must have the same keys, and the arrays for a
+particular key must be identically typed.
+
+Lookups get a bit trickier with multiple keys, since you'll need to
+construct a composite key with just the right shape to match the
+linkage. The :meth:`MultiKeyLinkage.key` method is provided to help
+with this.
+
+

--- a/docs/source/guides/cross-table-links.rst
+++ b/docs/source/guides/cross-table-links.rst
@@ -2,7 +2,7 @@ Linkages: Working with Multiple Tables
 ======================================
 
 .. currentmodule:: quivr
-		   
+
 .. note::
 
    See also: :ref:`linkage-example` for a worked example of using
@@ -97,6 +97,49 @@ over it in order of increasing ID, you can do this:
        left, right = lnk.select(k)
        # do something with the left and right tables
 
+If you happen to know that the keys are already unique, or already
+sorted, you might be able to skip some of those calls, or you might
+even be able to only use one of the key arrays.
+
+
+Slicing and Filtering
+---------------------
+
+The simplest way to do slicing and filtering is to slice and filter
+the original table. This works if you're providing one of the Table's
+columns directly as the key array, which is the most common case.
+
+For example, if I have a linkage ``link``, keyed by the ``id`` column
+of its left table, and its left table has a field named ``value`` that
+I'd like to filter on, I could use :meth:`Table.where`:
+
+.. code-block:: python
+
+   import pyarrow as pa
+   import pyarrow.compute as pc
+
+   # Filter the left table to positive value
+   left_positive = lnk.left_table.where(pc.field("value") > 0)
+
+   for id in left_positive.id:
+       left, right = lnk.select(id)
+       # do something with the left and right tables
+
+Similarly, to slice (for example, to get the first 10 rows), you can
+use slicing syntax on the table:
+
+.. code-block:: python
+
+   left_first_10 = lnk.left_table[:10]
+
+   for id in left_first_10.id:
+       left, right = lnk.select(id)
+       # do something with the left and right tables
+
+If you're using a key array that isn't a column on the table, then
+you'll need to do some more sophisticated bookkeeping, but the basic
+idea should be the same: generate an iterable of the keys you want,
+and then use the linkage to select the rows that match.
 
 
 Linking on multiple arrays
@@ -117,5 +160,3 @@ Lookups get a bit trickier with multiple keys, since you'll need to
 construct a composite key with just the right shape to match the
 linkage. The :meth:`MultiKeyLinkage.key` method is provided to help
 with this.
-
-

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -5,4 +5,5 @@ Guides
    :maxdepth: 2
 
    composition
+   cross-table-links
    serde

--- a/docs/source/guides/snippets/linkages/pets_tables.py
+++ b/docs/source/guides/snippets/linkages/pets_tables.py
@@ -1,0 +1,2 @@
+from quiver import *
+

--- a/docs/source/guides/snippets/serde/taxi2.py
+++ b/docs/source/guides/snippets/serde/taxi2.py
@@ -18,7 +18,7 @@ column_name_mapping = {
 
 data = TaxiData.from_parquet(
     "yellow__tripdata_2023-01.parquet",
-    column_name_mapping=column_name_mapping,
+    column_name_map=column_name_mapping,
 )
 print(data)
 # TaxiData(size=3066766)

--- a/docs/source/guides/snippets/serde/taxi3.py
+++ b/docs/source/guides/snippets/serde/taxi3.py
@@ -18,7 +18,7 @@ class TaxiData(Table):
         }
         return super().from_parquet(
             path,
-            column_name_mapping=column_name_mapping,
+            column_name_map=column_name_mapping,
         )
 
-taxi_data = TaxiData.from_parquet("./yellow_tripdata_2023-01.parquet")
+taxi_data = TaxiData.from_parquet("./yellow__tripdata_2023-01.parquet")

--- a/docs/source/guides/snippets/serde/taxi4.py
+++ b/docs/source/guides/snippets/serde/taxi4.py
@@ -18,7 +18,7 @@ class TaxiData(Table):
         }
         return super().from_parquet(
             path,
-            column_name_mapping=column_name_mapping,
+            column_name_map=column_name_mapping,
         )
 
 taxi_data = TaxiData.from_parquet("./yellow__tripdata_2023-01.parquet")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Quivr's tables are :ref:`composable <composition>`.
    installation
    basics
    guides/index
+   examples/index
    api/overview
 	     
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,17 @@ typecheck = [
 test = [
   "pytest --benchmark-disable ./test",
 ]
+doctest = [
+  "pytest --doctest-modules ./quivr"
+]
 benchmark = [
   "pytest --benchmark-only ./test"
+]
+gauntlet = [
+   "hatch run lint",
+   "hatch run typecheck",
+   "hatch run test",
+   "hatch run doctest",
 ]
 
 [tool.hatch.envs.docs]

--- a/quivr/__init__.py
+++ b/quivr/__init__.py
@@ -46,6 +46,7 @@ from .errors import InvariantViolatedError, TableFragmentedError, ValidationErro
 from .indexing import StringIndex
 from .matrix import MatrixArray, MatrixExtensionType
 from .tables import AnyTable, AttributeValueType, DataSourceType, Table
+from .linkage import Linkage
 from .validators import Validator, and_, eq, ge, gt, is_in, le, lt
 
 __all__ = [
@@ -111,4 +112,5 @@ __all__ = [
     "AnyTable",
     "MetadataDict",
     "Byteslike",
+    "Linkage",
 ]

--- a/quivr/__init__.py
+++ b/quivr/__init__.py
@@ -44,7 +44,7 @@ from .concat import concatenate
 from .defragment import defragment
 from .errors import InvariantViolatedError, TableFragmentedError, ValidationError
 from .indexing import StringIndex
-from .linkage import Linkage
+from .linkage import Linkage, MultiKeyLinkage
 from .matrix import MatrixArray, MatrixExtensionType
 from .tables import AnyTable, AttributeValueType, DataSourceType, Table
 from .validators import Validator, and_, eq, ge, gt, is_in, le, lt
@@ -113,4 +113,5 @@ __all__ = [
     "MetadataDict",
     "Byteslike",
     "Linkage",
+    "MultiKeyLinkage",
 ]

--- a/quivr/__init__.py
+++ b/quivr/__init__.py
@@ -44,9 +44,9 @@ from .concat import concatenate
 from .defragment import defragment
 from .errors import InvariantViolatedError, TableFragmentedError, ValidationError
 from .indexing import StringIndex
+from .linkage import Linkage
 from .matrix import MatrixArray, MatrixExtensionType
 from .tables import AnyTable, AttributeValueType, DataSourceType, Table
-from .linkage import Linkage
 from .validators import Validator, and_, eq, ge, gt, is_in, le, lt
 
 __all__ = [

--- a/quivr/indexing.py
+++ b/quivr/indexing.py
@@ -14,14 +14,6 @@ class StringIndex(Generic[T]):
     list of row indices. It can be used for fast lookups of sub-slices
     of a Table based on string values.
 
-    Example usage:
-
-    >>> from indexing import StringIndex
-    >>> from examples.coordinates import create_example_orbits
-    >>> orbits = create_example_orbits(1000)
-    >>> index = StringIndex(orbits, 'object_id')
-    >>> index.lookup('id990')
-    Orbit(size=1)
 
     This is equivalent to calling table.select("object_id", "id990"),
     but it is about 5x faster. The tradeoff is that building the

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -1,0 +1,87 @@
+from typing import Any, Optional
+import pyarrow as pa
+from . import tables
+from . import columns
+
+
+class ArrowStringArrayIndex:
+    """
+    Represents an index over the values in a PyArrow StringArray.
+    """
+
+    index: dict[pa.Scalar, pa.Int64Array]
+    values: set[pa.Scalar]
+    unique: bool
+
+    def __init__(self, array: pa.Array):
+        self.index = {}
+        self.values = set()
+        self.unique = True
+
+        if array.null_count > 0:
+            raise ValueError("Array must not contain null values to be an index")
+
+        in_progress_index = {}
+        for i in range(len(array)):
+            val = array[i]
+            if val in in_progress_index:
+                in_progress_index[val].append(i)
+                self.unique = False
+            else:
+                in_progress_index[val] = [i]
+            self.values.add(val)
+
+        for val, indices in in_progress_index.items():
+            self.index[val] = pa.array(indices)
+
+    def get(self, val: pa.Scalar) -> Optional[pa.Int64Array]:
+        return self.index.get(val, None)
+
+
+class Linkage:
+    def __init__(
+        self,
+        left_table: tables.Table,
+        right_table: tables.Table,
+        left_column: columns.Column,
+        right_column: columns.Column,
+    ):
+        self.left_table = left_table
+        self.right_table = right_table
+        self.left_column = left_column
+        self.right_column = right_column
+
+        self.left_index = self._build_index(left_table, left_column)
+        self.right_index = self._build_index(right_table, right_column)
+
+        self.all_unique_values = self.left_index.values.union(self.right_index.values)
+
+    def _build_index(self, table: tables.Table, column: columns.Column) -> ArrowStringArrayIndex:
+        arrow_array = table.column(column.name)
+        return ArrowStringArrayIndex(arrow_array)
+
+    def _select_left(self, val: Any) -> tables.Table:
+        left_indices = self.left_index.get(val)
+        if left_indices is None:
+            return self.left_table.empty()
+        else:
+            return self.left_table.take(left_indices)
+
+    def _select_right(self, val: Any) -> tables.Table:
+        right_indices = self.right_index.get(val)
+        if right_indices is None:
+            return self.right_table.empty()
+        else:
+            return self.right_table.take(right_indices)
+
+    def __getitem__(self, val: Any):
+        if not isinstance(val, pa.Scalar):
+            val = pa.scalar(val)
+        return self._select_left(val), self._select_right(val)
+
+    def __iter__(self):
+        for v in self.all_unique_values:
+            yield self[v]
+
+    def __len__(self):
+        return len(self.all_unique_values)

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -1,8 +1,8 @@
-from typing import Any, Optional, Iterator
+from typing import Any, Iterator, Optional
 
 import pyarrow as pa
 
-from . import columns, tables
+from . import tables
 
 
 class ArrowArrayIndex:

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -1,15 +1,16 @@
-from typing import Any, Optional
+from typing import Any, Optional, Iterator
+
 import pyarrow as pa
-from . import tables
-from . import columns
+
+from . import columns, tables
 
 
-class ArrowStringArrayIndex:
+class ArrowArrayIndex:
     """
-    Represents an index over the values in a PyArrow StringArray.
+    Represents an index over the values in a PyArrow Array.
     """
 
-    index: dict[pa.Scalar, pa.Int64Array]
+    index: dict[pa.Scalar, pa.UInt64Array]
     values: set[pa.Scalar]
     unique: bool
 
@@ -34,54 +35,133 @@ class ArrowStringArrayIndex:
         for val, indices in in_progress_index.items():
             self.index[val] = pa.array(indices)
 
-    def get(self, val: pa.Scalar) -> Optional[pa.Int64Array]:
+    def get(self, val: pa.Scalar) -> Optional[pa.UInt64Array]:
         return self.index.get(val, None)
 
 
 class Linkage:
+    """
+    A Linkage is a mapping of rows across two Tables.
+
+    The mapping is defined by a pair of arrays, one for each table, that
+    contain common values.
+
+    The Linkage can be used to iterate over all the unique values in the
+    linkage columns, and to select the rows from each table that match a
+    particular value.
+    """
+
+    left_table: tables.Table
+    right_table: tables.Table
+
+    left_index: ArrowArrayIndex
+    right_index: ArrowArrayIndex
+
+    all_unique_values: set[pa.Scalar]
+
     def __init__(
         self,
         left_table: tables.Table,
         right_table: tables.Table,
-        left_column: columns.Column,
-        right_column: columns.Column,
+        left_keys: pa.Array,
+        right_keys: pa.Array,
     ):
+        """
+        Create a new Linkage.
+
+        The linkage is defined by the two tables, and the two arrays of keys.
+
+        The keys must be the same length as the tables, and must not contain
+        null values.
+        """
+        if left_keys.null_count > 0:
+            raise ValueError("Left keys must not contain null values")
+        if right_keys.null_count > 0:
+            raise ValueError("Right keys must not contain null values")
+
+        if len(left_keys) != len(left_table):
+            raise ValueError("Left keys must have the same length as the left table")
+
+        if len(right_keys) != len(right_table):
+            raise ValueError("Right keys must have the same length as the right table")
+
         self.left_table = left_table
         self.right_table = right_table
-        self.left_column = left_column
-        self.right_column = right_column
 
-        self.left_index = self._build_index(left_table, left_column)
-        self.right_index = self._build_index(right_table, right_column)
+        self.left_index = ArrowArrayIndex(left_keys)
+        self.right_index = ArrowArrayIndex(right_keys)
 
         self.all_unique_values = self.left_index.values.union(self.right_index.values)
 
-    def _build_index(self, table: tables.Table, column: columns.Column) -> ArrowStringArrayIndex:
-        arrow_array = table.column(column.name)
-        return ArrowStringArrayIndex(arrow_array)
+    def select_left(self, val: Any) -> tables.Table:
+        """
+        Select the rows from the left table that match the given value.
 
-    def _select_left(self, val: Any) -> tables.Table:
+        If the value is not present in the left table, then an empty table is
+        returned.
+        """
+        if not isinstance(val, pa.Scalar):
+            val = pa.scalar(val)
+        return self._select_left(val)
+
+    def _select_left(self, val: pa.Scalar) -> tables.Table:
         left_indices = self.left_index.get(val)
         if left_indices is None:
             return self.left_table.empty()
         else:
             return self.left_table.take(left_indices)
 
-    def _select_right(self, val: Any) -> tables.Table:
+    def select_right(self, val: Any) -> tables.Table:
+        """
+        Select the rows from the right table that match the given value.
+
+        If the value is not present in the right table, then an empty table is
+        returned.
+        """
+        if not isinstance(val, pa.Scalar):
+            val = pa.scalar(val)
+        return self._select_right(val)
+
+    def _select_right(self, val: pa.Scalar) -> tables.Table:
         right_indices = self.right_index.get(val)
         if right_indices is None:
             return self.right_table.empty()
         else:
             return self.right_table.take(right_indices)
 
-    def __getitem__(self, val: Any):
+    def select(self, val: Any) -> tuple[tables.Table, tables.Table]:
+        """
+        Select the rows from both tables that match the given value.
+
+        If the value is not present in either table, then an empty table is
+        returned for that table.
+        """
         if not isinstance(val, pa.Scalar):
             val = pa.scalar(val)
         return self._select_left(val), self._select_right(val)
 
+    def __getitem__(self, val: Any):
+        return self.select(val)
+
+    def iterate(self) -> Iterator[tuple[pa.Scalar, tables.Table, tables.Table]]:
+        """
+        Returns an iterator over all the unique values in the linkage, and the rows from
+        each table that match that value.
+        """
+        for val in self.all_unique_values:
+            yield val, self._select_left(val), self._select_right(val)
+
     def __iter__(self):
-        for v in self.all_unique_values:
-            yield self[v]
+        return self.iterate()
 
     def __len__(self):
+        """Returns the number of unique values in the linkage."""
         return len(self.all_unique_values)
+
+
+def composite_array(*keys: list[pa.Array]) -> pa.Array:
+    """
+    Create a composite array from a list of arrays.
+    """
+    fields = [pa.field(f"key_{i}", k.type) for i, k in enumerate(keys)]
+    return pa.StructArray.from_arrays(keys, fields=fields)

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -71,6 +71,8 @@ class Linkage(Generic[LeftTable, RightTable]):
 
     left_keys: pa.Array
     right_keys: pa.Array
+
+    key_type: pa.DataType
     all_unique_values: set[pa.Scalar]
 
     def __init__(
@@ -99,6 +101,10 @@ class Linkage(Generic[LeftTable, RightTable]):
         if len(right_keys) != len(right_table):
             raise ValueError("Right keys must have the same length as the right table")
 
+        if left_keys.type != right_keys.type:
+            raise ValueError("Left and right keys must have the same data type")
+        self.key_type = left_keys.type
+
         self.left_table = left_table
         self.right_table = right_table
 
@@ -118,7 +124,7 @@ class Linkage(Generic[LeftTable, RightTable]):
         returned.
         """
         if not isinstance(val, pa.Scalar):
-            val = pa.scalar(val)
+            val = pa.scalar(val, self.key_type)
         return self._select_left(val)
 
     def _select_left(self, val: pa.Scalar) -> LeftTable:
@@ -136,7 +142,7 @@ class Linkage(Generic[LeftTable, RightTable]):
         returned.
         """
         if not isinstance(val, pa.Scalar):
-            val = pa.scalar(val)
+            val = pa.scalar(val, self.key_type)
         return self._select_right(val)
 
     def _select_right(self, val: pa.Scalar) -> RightTable:
@@ -154,7 +160,7 @@ class Linkage(Generic[LeftTable, RightTable]):
         returned for that table.
         """
         if not isinstance(val, pa.Scalar):
-            val = pa.scalar(val)
+            val = pa.scalar(val, self.key_type)
         return self._select_left(val), self._select_right(val)
 
     def __getitem__(self, val: Any) -> tuple[LeftTable, RightTable]:

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -55,6 +55,12 @@ class Linkage(Generic[LeftTable, RightTable]):
     :param right_table: The right table in the linkage.
     :param left_keys: The array of keys from the left table.
     :param right_keys: The array of keys from the right table.
+
+    :ivar Table left_table: The left table in the linkage.
+    :ivar Table right_table: The right table in the linkage.
+    :ivar pyarrow.Array left_keys: The array of keys for the left table.
+    :ivar pyarrow.Array right_keys: The array of keys for the right table.
+
     """
 
     left_table: LeftTable
@@ -63,6 +69,8 @@ class Linkage(Generic[LeftTable, RightTable]):
     left_index: ArrowArrayIndex
     right_index: ArrowArrayIndex
 
+    left_keys: pa.Array
+    right_keys: pa.Array
     all_unique_values: set[pa.Scalar]
 
     def __init__(
@@ -96,6 +104,9 @@ class Linkage(Generic[LeftTable, RightTable]):
 
         self.left_index = ArrowArrayIndex(left_keys)
         self.right_index = ArrowArrayIndex(right_keys)
+
+        self.left_keys = left_keys
+        self.right_keys = right_keys
 
         self.all_unique_values = self.left_index.values.union(self.right_index.values)
 

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -12,12 +12,10 @@ class ArrowArrayIndex:
 
     index: dict[pa.Scalar, pa.UInt64Array]
     values: set[pa.Scalar]
-    unique: bool
 
     def __init__(self, array: pa.Array):
         self.index = {}
         self.values = set()
-        self.unique = True
 
         if array.null_count > 0:
             raise ValueError("Array must not contain null values to be an index")
@@ -27,7 +25,6 @@ class ArrowArrayIndex:
             val = array[i]
             if val in in_progress_index:
                 in_progress_index[val].append(i)
-                self.unique = False
             else:
                 in_progress_index[val] = [i]
             self.values.add(val)

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -131,15 +131,11 @@ class Table:
         For example:
 
             >>> import quivr
-            >>> class MyTable(quivr.TableBase):
-            ...     schema = pyarrow.schema([
-            ...         pyarrow.field("a", pyarrow.string()),
-            ...         pyarrow.field("b", pyarrow.int64()),
-            ...     ])
+            >>> class MyTable(quivr.Table):
+            ...     a = quivr.StringColumn()
+            ...     b = quivr.Int64Column()
             ...
             >>> # All of these are equivalent:
-            >>> MyTable.from_data([["a", 1], ["b", 2]])
-            MyTable(size=2)
             >>> MyTable.from_data({"a": ["a", "b"], "b": [1, 2]})
             MyTable(size=2)
             >>> MyTable.from_data([{"a": "a", "b": 1}, {"a": "b", "b": 2}])
@@ -336,12 +332,12 @@ class Table:
             >>> class Inner(quivr.Table):
             ...     a = quivr.StringColumn()
             ...
-            >>> class Outer(quivr.TableBase):
+            >>> class Outer(quivr.Table):
             ...     z = quivr.StringColumn()
             ...     i = Inner.as_column()
             ...
             >>> data = [{"z": "v1", "i": {"a": "v1_in"}}, {"z": "v2", "i": {"a": "v2_in"}}]
-            >>> Outer.from_pylist(data)
+            >>> Outer.from_rows(data)
             Outer(size=2)
         """
         table = pa.Table.from_pylist(rows, schema=cls.schema)

--- a/test/test_linkage.py
+++ b/test/test_linkage.py
@@ -328,3 +328,27 @@ def test_benchmark_linkage_iteration(benchmark, left_table_size, right_table_siz
 def _noop_iterate(iterator):
     for _ in iterator:
         pass
+
+
+def test_access_keys_via_linkage():
+    class LeftSide(Table):
+        id = Int64Column(nullable=False)
+        x = Float64Column()
+
+    class RightSide(Table):
+        id = Int64Column(nullable=False)
+        leftside_id = Int64Column()
+
+    left = LeftSide.from_kwargs(
+        id=[1, 2, 3, 4, 5],
+        x=[1, 2, 3, 4, 5],
+    )
+    right = RightSide.from_kwargs(
+        id=[1, 2, 3, 4, 5],
+        leftside_id=[1, 1, 1, 2, 2],
+    )
+    link = Linkage(left, right, left.id, right.leftside_id)
+
+    assert link.left_keys == left.id
+    assert link.right_keys == right.leftside_id
+    assert link.left_keys != link.right_keys

--- a/test/test_linkage.py
+++ b/test/test_linkage.py
@@ -81,10 +81,11 @@ def test_linkage_iteration():
         right_keys=ephems.observer_code,
     )
 
-    for obs, eph in linkage:
+    for key, obs, eph in linkage:
         assert len(obs) == 1
         assert len(eph) == 3
-        assert pa.compute.all(pa.compute.equal(eph.observer_code, obs.code[0].as_py())).as_py()
+        assert pa.compute.all(pa.compute.equal(eph.observer_code, key)).as_py()
+        assert pa.compute.all(pa.compute.equal(obs.code, key)).as_py()
 
 
 def test_integer_linkage():

--- a/test/test_linkage.py
+++ b/test/test_linkage.py
@@ -1,0 +1,203 @@
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from quivr import Table, StringColumn, Float64Column, Int64Column
+from quivr.linkage import Linkage
+
+
+class Observers(Table):
+    code = StringColumn(nullable=False)
+    x = Float64Column()
+    y = Float64Column()
+    z = Float64Column()
+
+
+class Ephemeris(Table):
+    orbit_id = StringColumn(nullable=False)
+    observer_code = StringColumn(nullable=True)
+    ra = Float64Column()
+    dec = Float64Column()
+
+
+def test_linkage_indexing():
+    observers = Observers.from_kwargs(
+        code=["I41", "W84", "807"],
+        x=[1, 2, 3],
+        y=[4, 5, 6],
+        z=[7, 8, 9],
+    )
+
+    ephems = Ephemeris.from_kwargs(
+        orbit_id=["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+        observer_code=["I41", "I41", "I41", "W84", "W84", "W84", "807", "807", "807"],
+        ra=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        dec=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+    )
+
+    linkage = Linkage(
+        left_table=observers,
+        right_table=ephems,
+        left_column=Observers.code,
+        right_column=Ephemeris.observer_code,
+    )
+
+    have_i41 = linkage["I41"]
+    assert len(have_i41) == 2
+    have_i41_observers, have_i41_ephems = have_i41
+    assert have_i41_observers == Observers.from_kwargs(
+        code=["I41"],
+        x=[1],
+        y=[4],
+        z=[7],
+    )
+    assert have_i41_ephems == Ephemeris.from_kwargs(
+        orbit_id=["1", "2", "3"],
+        observer_code=["I41", "I41", "I41"],
+        ra=[1, 2, 3],
+        dec=[1, 2, 3],
+    )
+
+
+def test_linkage_iteration():
+    observers = Observers.from_kwargs(
+        code=["I41", "W84", "807"],
+        x=[1, 2, 3],
+        y=[4, 5, 6],
+        z=[7, 8, 9],
+    )
+
+    ephems = Ephemeris.from_kwargs(
+        orbit_id=["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+        observer_code=["I41", "I41", "I41", "W84", "W84", "W84", "807", "807", "807"],
+        ra=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        dec=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+    )
+
+    linkage = Linkage(
+        left_table=observers,
+        right_table=ephems,
+        left_column=Observers.code,
+        right_column=Ephemeris.observer_code,
+    )
+
+    for obs, eph in linkage:
+        assert len(obs) == 1
+        assert len(eph) == 3
+        assert pa.compute.all(pa.compute.equal(eph.observer_code, obs.code[0].as_py())).as_py()
+
+        
+def test_integer_linkage():
+    class LeftSide(Table):
+        id = Int64Column(nullable=False)
+        x = Float64Column()
+
+    class RightSide(Table):
+        id = Int64Column(nullable=False)
+        leftside_id = Int64Column()
+
+    left = LeftSide.from_kwargs(
+        id=[1, 2, 3, 4, 5],
+        x=[1, 2, 3, 4, 5],
+    )
+    right = RightSide.from_kwargs(
+        id=[1, 2, 3, 4, 5],
+        leftside_id=[1, 1, 1, 2, 2],
+    )
+    link = Linkage(left, right, LeftSide.id, RightSide.leftside_id)
+
+    # Bit counterintuitive, but the linkage provides empty RightSide
+    # tables for leftside_id=3, 4, 5.
+    assert len(link) == 5
+
+    have_left_1, have_right_1 = link[1]
+    assert have_left_1 == LeftSide.from_kwargs(
+        id=[1],
+        x=[1],
+    )
+    assert have_right_1 == RightSide.from_kwargs(
+        id=[1, 2, 3],
+        leftside_id=[1, 1, 1],
+    )
+
+    have_left_2, have_right_2 = link[2]
+    assert have_left_2 == LeftSide.from_kwargs(
+        id=[2],
+        x=[2],
+    )
+    assert have_right_2 == RightSide.from_kwargs(
+        id=[4, 5],
+        leftside_id=[2, 2],
+    )
+
+    have_left_3, have_right_3 = link[3]
+    assert have_left_3 == LeftSide.from_kwargs(
+        id=[3],
+        x=[3],
+    )
+    assert have_right_3 == RightSide.empty()
+
+    have_left_4, have_right_4 = link[4]
+    assert have_left_4 == LeftSide.from_kwargs(
+        id=[4],
+        x=[4],
+    )
+    assert have_right_4 == RightSide.empty()
+
+    have_left_5, have_right_5 = link[5]
+    assert have_left_5 == LeftSide.from_kwargs(
+        id=[5],
+        x=[5],
+    )
+    assert have_right_5 == RightSide.empty()
+
+
+@pytest.mark.benchmark(group="linkage-creation")
+@pytest.mark.parametrize("right_table_size", [100, 1000, 100000], ids=lambda x: f"right={x}")
+@pytest.mark.parametrize("left_table_size", [10, 100, 1000], ids=lambda x: f"left={x}")
+def test_benchmark_linkage_creation(benchmark, left_table_size, right_table_size):
+    unique_observers = np.arange(left_table_size).astype(str)
+    observers = Observers.from_kwargs(
+        code=unique_observers,
+        x=np.ones(left_table_size),
+        y=np.ones(left_table_size),
+        z=np.ones(left_table_size),
+    )
+
+    ephems = Ephemeris.from_kwargs(
+        orbit_id=np.arange(right_table_size).astype(str),
+        observer_code=np.random.choice(unique_observers, size=right_table_size),
+        ra=np.ones(right_table_size),
+        dec=np.ones(right_table_size),
+    )
+
+    benchmark(lambda: Linkage(observers, ephems, Observers.code, Ephemeris.observer_code))
+
+@pytest.mark.benchmark(group="linkage-iteration")
+@pytest.mark.parametrize("right_table_size", [100, 1000, 100000], ids=lambda x: f"right={x}")
+@pytest.mark.parametrize("left_table_size", [10, 100, 1000], ids=lambda x: f"left={x}")
+def test_benchmark_linkage_iteration(benchmark, left_table_size, right_table_size):
+    unique_observers = np.arange(left_table_size).astype(str)
+    observers = Observers.from_kwargs(
+        code=unique_observers,
+        x=np.ones(left_table_size),
+        y=np.ones(left_table_size),
+        z=np.ones(left_table_size),
+    )
+
+    ephems = Ephemeris.from_kwargs(
+        orbit_id=np.arange(right_table_size).astype(str),
+        observer_code=np.random.choice(unique_observers, size=right_table_size),
+        ra=np.ones(right_table_size),
+        dec=np.ones(right_table_size),
+    )
+
+    linkage = Linkage(observers, ephems, Observers.code, Ephemeris.observer_code)
+
+    benchmark(lambda: _noop_iterate(linkage))
+
+def _noop_iterate(iterator):
+    for _ in iterator:
+        pass
+
+    

--- a/test/typing_tests/columns.py
+++ b/test/typing_tests/columns.py
@@ -23,7 +23,7 @@ assert_type(instance, MyTable)
 # Instance attributes should return pyarrow types
 assert_type(instance.string_col, pyarrow.StringArray)
 assert_type(instance.int8_col, pyarrow.Int8Array)
-assert_type(instance.float64_col, pyarrow.Float64Array)
+assert_type(instance.float64_col, pyarrow.lib.DoubleArray)
 
 # Class-level attributes should be the columns themselves
 assert_type(MyTable.string_col, quivr.StringColumn)

--- a/test/typing_tests/linkages.py
+++ b/test/typing_tests/linkages.py
@@ -1,0 +1,36 @@
+from typing_extensions import assert_type
+
+import quivr
+
+
+class MyLeftTable(quivr.Table):
+    id_col = quivr.Int64Column()
+    x = quivr.Float64Column()
+
+
+class MyRightTable(quivr.Table):
+    l_id_col = quivr.Int64Column()
+    y = quivr.Float64Column()
+
+
+left_val = MyLeftTable.from_kwargs(id_col=[1, 2, 3], x=[1.0, 2.0, 3.0])
+
+right_val = MyRightTable.from_kwargs(l_id_col=[1, 2, 3, 4], y=[1.0, 2.0, 3.0, 4.0])
+
+linkage = quivr.Linkage(left_val, right_val, left_val.id_col, right_val.l_id_col)
+
+assert_type(linkage, quivr.Linkage[MyLeftTable, MyRightTable])
+
+assert_type(linkage.select_left(2), MyLeftTable)
+assert_type(linkage.select_right(2), MyRightTable)
+
+assert_type(linkage.select(2), tuple[MyLeftTable, MyRightTable])
+
+multi_linkage = quivr.MultiKeyLinkage(
+    left_val,
+    right_val,
+    {"id": left_val.id_col, "pos": left_val.x},
+    {"id": right_val.l_id_col, "pos": right_val.y},
+)
+
+assert_type(multi_linkage, quivr.MultiKeyLinkage[MyLeftTable, MyRightTable])


### PR DESCRIPTION
This adds "Linkages" which are tools for efficiently cross-referencing data in different tables.

The tests are okay at illustrating how it works. Here's the idea:

Tables can be linked by any arbitrary Arrow arrays (so you can use composite keys or whatever, if you like). 

Here's the most basic usage - link some Ephemeris rows to some Observers rows:
```py
# I have a few observer locations
observers = Observers.from_kwargs(
    code=["I41", "W84", "807"],
    x=[1, 2, 3],
    y=[4, 5, 6],
    z=[7, 8, 9],
)

# I have a bunch of ephems, which repeat the observers, and I don't want to redundantly include them
ephems = Ephemeris.from_kwargs(
    orbit_id=["1", "2", "3", "4", "5", "6", "7", "8", "9"],
    observer_code=["I41", "I41", "I41", "W84", "W84", "W84", "807", "807", "807"],
    ra=[1, 2, 3, 4, 5, 6, 7, 8, 9],
    dec=[1, 2, 3, 4, 5, 6, 7, 8, 9],
)

# Linkage gets explicitly constructed:
linkage = Linkage(
    left_table=observers,
    right_table=ephems,
    left_keys=observers.code,
    right_keys=ephems.observer_code,
)
```

Once this is constructed, you get a few methods:

### Select

The `Linkage.select(key)` method grabs all rows that match key from the two tables, returning them inside their quivr.Table wrappers.

If the key is missing in either table, you get an empty table (size=0).

`__getitem__` is an alias for `select`.

This operation does not copy any data.
```py
>>> linkage.select("I41")
(Observers(size=1), Ephemeris(size=3))

>>> linkage["I41"]
(Observers(size=1), Ephemeris(size=3))

>>> linkage["ZZZ"]
(Observers(size=0), Ephemeris(size=0))
```

### iterate
`Linkage.iterate()` returns an iterator that runs over all the unique values in the linkage, gathering the matching values.
```py
>>> for (key, obs_i, ephem_i) in linkage.iterate():
...     print(key, obs_i, ephem_i)
...
I41 Observers(size=1) Ephemeris(size=3)
W84 Observers(size=1) Ephemeris(size=3)
807 Observers(size=1) Ephemeris(size=3)
```

`__iter__` calls `Linkage.iterate()`, so you can also iterate over the linkage directly.

### select_left, select_right

These are just like `select`, but target just one of the two tables.
```py
>>> linkage.select_left("W84")
Observers(size=1)
>>> linkage.select_right("W84")
Ephemeris(size=3)
```

## Limitations

The keys used must not contain any null values. They _don't_ need to be unique, and they may be disjoint.

## Performance

Constructing a linkage costs about 600ns per element in the input key arrays (so, 0.6s for 1 million elements).

Iterating over a linkage costs about 15us per element.

Querying a linkage costs about 20us. (you can get this down to 15us if you're willing to mess around with `PyArrow.Scalar`.
