### PR TITLE
Use 'import quivr as qv' style throughout

### DIFF
--- a/docs/source/api/attributes.rst
+++ b/docs/source/api/attributes.rst
@@ -17,14 +17,14 @@ Example usage:
 
 .. code-block:: py
 
-   from quivr import Table, StringAttribute, Float64Column
+   import quivr as qv
 
-   class Observations(Table):
-       x = Float64Column()
-       y = Float64Column()
-       z = Float64Column()
+   class Observations(qv.Table):
+       x = qv.Float64Column()
+       y = qv.Float64Column()
+       z = qv.Float64Column()
 
-       reference_frame = StringAttribute(default="earth")
+       reference_frame = qv.StringAttribute(default="earth")
 
 
     obs = Observations.from_data(
@@ -46,9 +46,9 @@ the Attribute constructor:
 
 .. code-block:: py
 
-   class Dataset(Table):
-       measurements = Int64Column()
-       source = StringAttribute(mutable=True)
+   class Dataset(qv.Table):
+       measurements = qv.Int64Column()
+       source = qv.StringAttribute(mutable=True)
 
    p = Dataset.from_data(measurements=[1, 2, 3], source="earth")
    p.source = "mars"  # only if p.source is mutable!
@@ -61,11 +61,11 @@ re-attach the sub-table to the parent. This is easier to explain with code:
 
 .. code-block:: py
 
-   class Dataset(Table):
-       measurements = Int64Column()
-       source = StringAttribute(mutable=True)
+   class Dataset(qv.Table):
+       measurements = qv.Int64Column()
+       source = qv.StringAttribute(mutable=True)
 
-   class Database(Table):
+   class Database(qv.Table):
        datasets = Dataset.as_column()
 
    d = Database.from_data(

--- a/docs/source/api/column_validators.rst
+++ b/docs/source/api/column_validators.rst
@@ -22,10 +22,11 @@ example, this code validates the ``size`` column is between 5 and 30:
 
 .. code-block:: py
 
-   from quivr import Table, Int8Column, ge, le, and_
+   import quivr as qv
+   from quivr import and_, ge, le
 
-   class Hat(Table):
-       size = Int8Column(validator=and_(ge(5), le(30)))
+   class Hat(qv.Table):
+       size = qv.Int8Column(validator=and_(ge(5), le(30)))
        
 
 .. autofunction:: eq

--- a/docs/source/api/columns.rst
+++ b/docs/source/api/columns.rst
@@ -9,12 +9,12 @@ class attributes on :class:`Table` subclasses. For example:
 
 .. code-block:: py
 
-   import quivr
+   import quivr as qv
    
-   class Person(quivr.Table):
-       name = quivr.StringColumn()
-       age = quivr.Uint8Column()
-       favorite_books = quivr.ListColumn(quivr.StringColumn())
+   class Person(qv.Table):
+       name = qv.StringColumn()
+       age = qv.Uint8Column()
+       favorite_books = qv.ListColumn(quivr.StringColumn())
 
 The ``Person`` Table defined above has three columns: a string name, a
 uint8 age, and a list of strings for books.
@@ -33,25 +33,25 @@ These are the simplest column types. They all are initialized the same way:
 
 .. code-block:: py
 
-   import quivr
+   import quivr as qv
 
-   class MyTable(quivr.Table)
+   class MyTable(qv.Table)
        # With no arguments, you get a nullable column that doesn't validate data.
-       # This could be quivr.Uint8Column(), or quivr.StringColumn(), whatever
-       quivr.Int32Column()
+       # This could be qv.Uint8Column(), or qv.StringColumn(), whatever
+       qv.Int32Column()
 
        # Pass nullable=False to get a non-nullable column.
-       quivr.Int32Column(nullable=False)
+       qv.Int32Column(nullable=False)
 
        # Pass a validator to check the input data against a constraint.
-       quivr.Int32Column(validator=quivr.gt(0))
+       qv.Int32Column(validator=qv.gt(0))
 
        # Pass metadata for arbitrary extra information to
        # include. Metadata should be a string-to-string dictionary.
-       quivr.Int32Column(metadata={'units': 'seconds'})
+       qv.Int32Column(metadata={'units': 'seconds'})
 
        # Set a default value to be used if any inputs are null
-       quivr.Int32Column(nullable=False, default=3)
+       qv.Int32Column(nullable=False, default=3)
 
 
 When you access a column of a primitive type on a :class:`Table`

--- a/docs/source/api/errors.rst
+++ b/docs/source/api/errors.rst
@@ -21,3 +21,6 @@
 
 .. autoexception:: AttributeImmutableError
    :members:
+
+.. autoexception:: InvalidColumnDefault
+   :members:

--- a/docs/source/examples/linkages.py
+++ b/docs/source/examples/linkages.py
@@ -1,18 +1,18 @@
-from quivr import Table, StringColumn, UInt32Column, Linkage, concatenate
+import quivr as qv
 
-class People(Table):
-    id = UInt32Column()
-    name = StringColumn()
-    age = UInt32Column()
+class People(qv.Table):
+    id = qv.UInt32Column()
+    name = qv.StringColumn()
+    age = qv.UInt32Column()
 
-class Pets(Table):
-    name = StringColumn()
-    owner_id = UInt32Column()
-    species = StringColumn()
+class Pets(qv.Table):
+    name = qv.StringColumn()
+    owner_id = qv.UInt32Column()
+    species = qv.StringColumn()
 
 # L13
 
-class PetsAndOwners(Table):
+class PetsAndOwners(qv.Table):
     owner = People.as_column()
     pets = Pets.as_column()
 
@@ -30,7 +30,7 @@ pets = Pets.from_data(
     species=['Dog', 'Dog', 'Cat', 'Dog', 'Dog', 'Cat', 'Dog']
 )
 
-linkage = Linkage(people, pets, people.id, pets.owner_id)
+linkage = qv.Linkage(people, pets, people.id, pets.owner_id)
 
 # L35
 
@@ -65,8 +65,8 @@ for id, owner, pets in linkage:
     if 'Dog' in pets.species.tolist():
         dog_owners.append(owner)
 
-cat_owners = concatenate(cat_owners)
-dog_owners = concatenate(dog_owners)
+cat_owners = qv.concatenate(cat_owners)
+dog_owners = qv.concatenate(dog_owners)
 
 print(cat_owners.age.to_numpy().mean())
 # 37.5

--- a/docs/source/guides/snippets/serde/taxi1.py
+++ b/docs/source/guides/snippets/serde/taxi1.py
@@ -1,12 +1,12 @@
-from quivr import *
+import quivr as qv
 
-class TaxiData(Table):
-    VendorID = Int64Column()
-    tpep_pickup_datetime = TimestampColumn(unit="us")
-    tpep_dropoff_datetime = TimestampColumn(unit="us")
-    passenger_count = Float64Column()
-    trip_distance = Float64Column()
-    RatecodeID = Float64Column()
+class TaxiData(qv.Table):
+    VendorID = qv.Int64Column()
+    tpep_pickup_datetime = qv.TimestampColumn(unit="us")
+    tpep_dropoff_datetime = qv.TimestampColumn(unit="us")
+    passenger_count = qv.Float64Column()
+    trip_distance = qv.Float64Column()
+    RatecodeID = qv.Float64Column()
     ...
 
 

--- a/docs/source/guides/snippets/serde/taxi2.py
+++ b/docs/source/guides/snippets/serde/taxi2.py
@@ -1,12 +1,12 @@
-from quivr import *
+import quivr as qv
 
-class TaxiData(Table):
-    vendor_id = Int64Column()
-    pickup = TimestampColumn(unit="us")
-    dropoff = TimestampColumn(unit="us")
-    passenger_count = Float64Column()
-    trip_distance = Float64Column()
-    rate_code = Float64Column()
+class TaxiData(qv.Table):
+    vendor_id = qv.Int64Column()
+    pickup = qv.TimestampColumn(unit="us")
+    dropoff = qv.TimestampColumn(unit="us")
+    passenger_count = qv.Float64Column()
+    trip_distance = qv.Float64Column()
+    rate_code = qv.Float64Column()
     ...
 
 column_name_mapping = {

--- a/docs/source/guides/snippets/serde/taxi3.py
+++ b/docs/source/guides/snippets/serde/taxi3.py
@@ -1,12 +1,12 @@
-from quivr import *
+import quivr as qv
 
-class TaxiData(Table):
-    vendor_id = Int64Column()
-    pickup = TimestampColumn(unit="us")
-    dropoff = TimestampColumn(unit="us")
-    passenger_count = Float64Column()
-    trip_distance = Float64Column()
-    rate_code = Float64Column()
+class TaxiData(qv.Table):
+    vendor_id = qv.Int64Column()
+    pickup = qv.TimestampColumn(unit="us")
+    dropoff = qv.TimestampColumn(unit="us")
+    passenger_count = qv.Float64Column()
+    trip_distance = qv.Float64Column()
+    rate_code = qv.Float64Column()
 
     @classmethod
     def from_parquet(cls, path):

--- a/docs/source/guides/snippets/serde/taxi4.py
+++ b/docs/source/guides/snippets/serde/taxi4.py
@@ -1,12 +1,12 @@
-from quivr import *
+import quivr as qv
 
-class TaxiData(Table):
-    vendor_id = UInt8Column()
-    pickup = TimestampColumn(unit="us")
-    dropoff = TimestampColumn(unit="us")
-    passenger_count = UInt8Column()
-    trip_distance = Float64Column()
-    rate_code = UInt8Column()
+class TaxiData(qv.Table):
+    vendor_id = qv.UInt8Column()
+    pickup = qv.TimestampColumn(unit="us")
+    dropoff = qv.TimestampColumn(unit="us")
+    passenger_count = qv.UInt8Column()
+    trip_distance = qv.Float64Column()
+    rate_code = qv.UInt8Column()
 
     @classmethod
     def from_parquet(cls, path):

--- a/examples/coordinates.py
+++ b/examples/coordinates.py
@@ -3,17 +3,17 @@ import numpy.typing as npt
 import pyarrow as pa
 import pyarrow.compute as pc
 
-from quivr import Table, Float64Column, ListColumn, StringColumn
+import quivr as qv
 
 
-class CartesianCoordinates(Table):
-    x = Float64Column()
-    y = Float64Column()
-    z = Float64Column()
-    vx = Float64Column()
-    vy = Float64Column()
-    vz = Float64Column()
-    covariance = ListColumn(pa.float64())
+class CartesianCoordinates(qv.Table):
+    x = qv.Float64Column()
+    y = qv.Float64Column()
+    z = qv.Float64Column()
+    vx = qv.Float64Column()
+    vy = qv.Float64Column()
+    vz = qv.Float64Column()
+    covariance = qv.ListColumn(pa.float64())
 
     def covariance_matrix(self) -> npt.NDArray[np.float64]:
         raw = self.column("covariance").to_numpy()
@@ -32,12 +32,12 @@ class CartesianCoordinates(Table):
         )
 
 
-class Orbit(Table):
+class Orbit(qv.Table):
     coords = CartesianCoordinates.as_column()
-    epoch = Float64Column()
-    object_id = StringColumn()
+    epoch = qv.Float64Column()
+    object_id = qv.StringColumn()
 
 
-class Etc(Table):
+class Etc(qv.Table):
     orbit = Orbit.as_column()
-    thing = Float64Column()
+    thing = qv.Float64Column()

--- a/quivr/__init__.py
+++ b/quivr/__init__.py
@@ -44,6 +44,7 @@ from .concat import concatenate
 from .defragment import defragment
 from .errors import (
     AttributeImmutableError,
+    InvalidColumnDefault,
     InvariantViolatedError,
     LinkageCombinationError,
     TableFragmentedError,
@@ -80,6 +81,7 @@ __all__ = [
     "Int64Column",
     "Int8Column",
     "IntAttribute",
+    "InvalidColumnDefault",
     "InvariantViolatedError",
     "LargeBinaryColumn",
     "LargeListColumn",

--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -138,7 +138,7 @@ T = TypeVar("T", bound=tables.Table)
 
 class SubTableColumn(Column, Generic[T]):
     """
-    A column which represents an embedded Quivr table.
+    A column which represents an embedded quivr table.
 
     :param table_type: The type of the table to embed.
     :param nullable: Whether the column can contain null values.
@@ -1150,13 +1150,14 @@ class ListColumn(Column):
 
     The values in the list can be of any type.
 
-    Note that all quivr tables.Tables are storing lists of values, so this
+    Note that all quivr Tables are storing lists of values, so this
     column type is only useful for storing lists of lists.
 
     :param value_type: The type of the values in the list.
     :param nullable: Whether the list can contain null values.
     :param metadata: A dictionary of metadata to attach to the column.
     :param validator: A validator to run against the column's values.
+
     """
 
     def __init__(

--- a/quivr/concat.py
+++ b/quivr/concat.py
@@ -2,8 +2,7 @@ from typing import Iterator
 
 import pyarrow as pa
 
-from . import errors, tables
-from .defragment import defragment
+from . import defragment, errors, tables
 
 
 def concatenate(values: Iterator[tables.AnyTable], defrag: bool = True) -> tables.AnyTable:
@@ -44,5 +43,5 @@ def concatenate(values: Iterator[tables.AnyTable], defrag: bool = True) -> table
     table = pa.Table.from_batches(batches)
     result = first_cls.from_pyarrow(table=table)
     if defrag:
-        result = defragment(result)
+        result = defragment.defragment(result)
     return result

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -197,18 +197,18 @@ class MultiKeyLinkage(Linkage[LeftTable, RightTable]):
       - be the same length as the associated table
 
     Example:
-        >>> from quivr import *
-        >>> class Positions(Table):
-        ...     x = Float32Column()
-        ...     y = Float32Column()
-        ...     time = TimestampColumn(unit="s")
-        ...     id = UInt32Column()
+        >>> import quivr as qv
+        >>> class Positions(qv.Table):
+        ...     x = qv.Float32Column()
+        ...     y = qv.Float32Column()
+        ...     time = qv.TimestampColumn(unit="s")
+        ...     id = qv.UInt32Column()
         ...
-        >>> class Velocities(tables.Table):
-        ...     vx = Float32Column()
-        ...     vy = Float32Column()
-        ...     time = TimestampColumn(unit="s")
-        ...     id = UInt32Column()
+        >>> class Velocities(qv.Table):
+        ...     vx = qv.Float32Column()
+        ...     vy = qv.Float32Column()
+        ...     time = qv.TimestampColumn(unit="s")
+        ...     id = qv.UInt32Column()
         ...
         >>> positions = Positions.from_data(
         ...     x=[0.0, 1.0, 2.0, 3.0, 4.0],
@@ -222,7 +222,7 @@ class MultiKeyLinkage(Linkage[LeftTable, RightTable]):
         ...     time=[0, 1, 2, 3, 4],
         ...     id=[0, 1, 1, 2, 2],
         ... )
-        >>> linkage = MultiKeyLinkage(
+        >>> linkage = qv.MultiKeyLinkage(
         ...     positions,
         ...     velocities,
         ...     {"id": positions.id, "time": positions.time},
@@ -235,8 +235,6 @@ class MultiKeyLinkage(Linkage[LeftTable, RightTable]):
         [('id', 1), ('time', datetime.datetime(1970, 1, 1, 0, 0, 2))] Positions(size=1) Velocities(size=1)
         [('id', 2), ('time', datetime.datetime(1970, 1, 1, 0, 0, 3))] Positions(size=1) Velocities(size=1)
         [('id', 2), ('time', datetime.datetime(1970, 1, 1, 0, 0, 4))] Positions(size=1) Velocities(size=1)
-
-
 
 
     :param left_table: The left table to link.
@@ -323,18 +321,18 @@ class MultiKeyLinkage(Linkage[LeftTable, RightTable]):
         Returns a composite key scalar for the given values.
 
         Example:
-            >>> from quivr import *
-            >>> class Positions(Table):
-            ...     x = Float32Column()
-            ...     y = Float32Column()
-            ...     time = TimestampColumn(unit="s")
-            ...     id = UInt32Column()
+            >>> import quivr as qv
+            >>> class Positions(qv.Table):
+            ...     x = qv.Float32Column()
+            ...     y = qv.Float32Column()
+            ...     time = qv.TimestampColumn(unit="s")
+            ...     id = qv.UInt32Column()
             ...
-            >>> class Velocities(tables.Table):
-            ...     vx = Float32Column()
-            ...     vy = Float32Column()
-            ...     time = TimestampColumn(unit="s")
-            ...     id = UInt32Column()
+            >>> class Velocities(qv.Table):
+            ...     vx = qv.Float32Column()
+            ...     vy = qv.Float32Column()
+            ...     time = qv.TimestampColumn(unit="s")
+            ...     id = qv.UInt32Column()
             ...
             >>> positions = Positions.from_data(
             ...     x=[0.0, 1.0, 2.0, 3.0, 4.0],
@@ -348,7 +346,7 @@ class MultiKeyLinkage(Linkage[LeftTable, RightTable]):
             ...     time=[0, 1, 2, 3, 4],
             ...     id=[0, 1, 1, 2, 2],
             ... )
-            >>> linkage = MultiKeyLinkage(
+            >>> linkage = qv.MultiKeyLinkage(
             ...     positions,
             ...     velocities,
             ...     {"time": positions.time, "id": positions.id},

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -170,10 +170,10 @@ class Table:
 
         For example:
 
-            >>> import quivr
-            >>> class MyTable(quivr.Table):
-            ...     a = quivr.StringColumn()
-            ...     b = quivr.Int64Column()
+            >>> import quivr as qv
+            >>> class MyTable(qv.Table):
+            ...     a = qv.StringColumn()
+            ...     b = qv.Int64Column()
             ...
             >>> # All of these are equivalent:
             >>> MyTable.from_data({"a": ["a", "b"], "b": [1, 2]})
@@ -380,12 +380,12 @@ class Table:
         :returns: A Table object.
 
         Examples:
-            >>> import quivr
-            >>> class Inner(quivr.Table):
-            ...     a = quivr.StringColumn()
+            >>> import quivr as qv
+            >>> class Inner(qv.Table):
+            ...     a = qv.StringColumn()
             ...
-            >>> class Outer(quivr.Table):
-            ...     z = quivr.StringColumn()
+            >>> class Outer(qv.Table):
+            ...     z = qv.StringColumn()
             ...     i = Inner.as_column()
             ...
             >>> data = [{"z": "v1", "i": {"a": "v1_in"}}, {"z": "v2", "i": {"a": "v2_in"}}]
@@ -1004,11 +1004,11 @@ class Table:
         :param expr: A pyarrow Expression to apply to the table.
 
         Examples:
-            >>> from quivr import Table, Int64Column
+            >>> import quivr as qv
             >>> import pyarrow.compute as pc
-            >>> class MyTable(Table):
-            ...     x = Int64Column()
-            ...     y = Int64Column()
+            >>> class MyTable(qv.Table):
+            ...     x = qv.Int64Column()
+            ...     y = qv.Int64Column()
             >>> t = MyTable.from_data(x=[1, 2, 3], y=[4, 5, 6])
             >>> filtered = t.where(pc.field("x") > 1)
             >>> print(filtered.x.to_pylist())

--- a/test/test_attributes.py
+++ b/test/test_attributes.py
@@ -2,22 +2,15 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from quivr import (
-    AttributeImmutableError,
-    FloatAttribute,
-    Int64Column,
-    IntAttribute,
-    StringAttribute,
-    Table,
-)
+import quivr as qv
 
 
 def test_multiple_attributes():
-    class MyTable(Table):
-        vals = Int64Column()
-        name = StringAttribute()
-        id = IntAttribute()
-        fval = FloatAttribute()
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        name = qv.StringAttribute()
+        id = qv.IntAttribute()
+        fval = qv.FloatAttribute()
 
     table = MyTable.from_data(name="foo", id=1, vals=[1, 2, 3], fval=2.5)
     assert table.attributes() == {
@@ -28,17 +21,17 @@ def test_multiple_attributes():
 
 
 def test_nested_attribute_metadata():
-    class Inner(Table):
-        x = Int64Column()
-        id1 = StringAttribute()
+    class Inner(qv.Table):
+        x = qv.Int64Column()
+        id1 = qv.StringAttribute()
 
-    class Middle(Table):
+    class Middle(qv.Table):
         inner = Inner.as_column()
-        id2 = StringAttribute()
+        id2 = qv.StringAttribute()
 
-    class Outer(Table):
+    class Outer(qv.Table):
         middle = Middle.as_column()
-        id3 = StringAttribute()
+        id3 = qv.StringAttribute()
 
     inner = Inner.from_kwargs(x=[1, 2, 3], id1="a")
     middle = Middle.from_kwargs(
@@ -60,12 +53,12 @@ def test_nested_attribute_metadata():
 
 
 def test_nested_table():
-    class Inner(Table):
-        x = Int64Column()
-        id = IntAttribute()
+    class Inner(qv.Table):
+        x = qv.Int64Column()
+        id = qv.IntAttribute()
 
-    class Outer(Table):
-        name = StringAttribute()
+    class Outer(qv.Table):
+        name = qv.StringAttribute()
         inner = Inner.as_column()
 
     table = Outer.from_data(
@@ -81,12 +74,12 @@ def test_nested_table():
 
 def test_nested_table_shadowing():
     # Test that reusing a name at two levels is safe.
-    class Inner(Table):
-        x = Int64Column()
-        id = IntAttribute()
+    class Inner(qv.Table):
+        x = qv.Int64Column()
+        id = qv.IntAttribute()
 
-    class Outer(Table):
-        id = IntAttribute()
+    class Outer(qv.Table):
+        id = qv.IntAttribute()
         inner = Inner.as_column()
 
     table = Outer.from_data(
@@ -101,12 +94,12 @@ def test_nested_table_shadowing():
 
 
 def test_nested_table_mutability():
-    class Inner(Table):
-        x = Int64Column()
-        id = IntAttribute(mutable=True)
+    class Inner(qv.Table):
+        x = qv.Int64Column()
+        id = qv.IntAttribute(mutable=True)
 
-    class Outer(Table):
-        name = StringAttribute(mutable=True)
+    class Outer(qv.Table):
+        name = qv.StringAttribute(mutable=True)
         inner = Inner.as_column()
 
     table = Outer.from_data(
@@ -131,12 +124,12 @@ def test_nested_table_mutability():
 
 
 def test_csv_nested_table(tmp_path):
-    class Inner(Table):
-        x = Int64Column()
-        id = IntAttribute()
+    class Inner(qv.Table):
+        x = qv.Int64Column()
+        id = qv.IntAttribute()
 
-    class Outer(Table):
-        name = StringAttribute()
+    class Outer(qv.Table):
+        name = qv.StringAttribute()
         inner = Inner.as_column()
 
     table = Outer.from_data(
@@ -154,9 +147,9 @@ def test_csv_nested_table(tmp_path):
 
 
 class TestConstructors:
-    class MyTable(Table):
-        vals = Int64Column()
-        name = StringAttribute()
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        name = qv.StringAttribute()
 
     def test_from_dataframe(self):
         df = pd.DataFrame({"vals": [1, 2, 3]})
@@ -164,14 +157,14 @@ class TestConstructors:
         assert table.name == "foo"
 
     def test_from_flat_dataframe(self):
-        class Inner(Table):
-            x = Int64Column()
-            id = IntAttribute()
+        class Inner(qv.Table):
+            x = qv.Int64Column()
+            id = qv.IntAttribute()
 
-        class Outer(Table):
-            y = Int64Column()
+        class Outer(qv.Table):
+            y = qv.Int64Column()
             inner = Inner.as_column()
-            name = StringAttribute()
+            name = qv.StringAttribute()
 
         df = pd.DataFrame({"inner.x": [1, 2, 3], "y": [4, 5, 6]})
         table = Outer.from_flat_dataframe(df, name="foo")
@@ -203,10 +196,10 @@ class TestConstructors:
 
 
 class TestStringAttribute:
-    class MyTable(Table):
-        vals = Int64Column()
-        name = StringAttribute()
-        mutable_name = StringAttribute(mutable=True, default="bar")
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        name = qv.StringAttribute()
+        mutable_name = qv.StringAttribute(mutable=True, default="bar")
 
     def test_from_data(self):
         table = self.MyTable.from_data(name="foo", vals=[1, 2, 3])
@@ -226,7 +219,7 @@ class TestStringAttribute:
 
     def test_immutable(self):
         table = self.MyTable.from_data(name="foo", vals=[1, 2, 3])
-        with pytest.raises(AttributeImmutableError):
+        with pytest.raises(qv.AttributeImmutableError):
             table.name = "bar"
 
     def test_parquet_round_trip(self, tmp_path):
@@ -249,10 +242,10 @@ class TestStringAttribute:
 
 
 class TestIntAttribute:
-    class MyTable(Table):
-        vals = Int64Column()
-        id = IntAttribute()
-        mutable_id = IntAttribute(mutable=True, default=1)
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        id = qv.IntAttribute()
+        mutable_id = qv.IntAttribute(mutable=True, default=1)
 
     def test_from_data(self):
         table = self.MyTable.from_data(id=1, vals=[1, 2, 3])
@@ -267,7 +260,7 @@ class TestIntAttribute:
 
     def test_immutable(self):
         table = self.MyTable.from_data(id=1, vals=[1, 2, 3])
-        with pytest.raises(AttributeImmutableError):
+        with pytest.raises(qv.AttributeImmutableError):
             table.id = 2
 
     def test_parquet_round_trip(self, tmp_path):
@@ -290,10 +283,10 @@ class TestIntAttribute:
 
 
 class TestFloatAttribute:
-    class MyTable(Table):
-        vals = Int64Column()
-        id = FloatAttribute()
-        mutable_id = FloatAttribute(mutable=True, default=1.5)
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        id = qv.FloatAttribute()
+        mutable_id = qv.FloatAttribute(mutable=True, default=1.5)
 
     def test_from_data(self):
         table = self.MyTable.from_data(id=1.5, vals=[1, 2, 3])
@@ -308,7 +301,7 @@ class TestFloatAttribute:
 
     def test_immutable(self):
         table = self.MyTable.from_data(id=1.5, vals=[1, 2, 3])
-        with pytest.raises(AttributeImmutableError):
+        with pytest.raises(qv.AttributeImmutableError):
             table.id = 2.5
 
     def test_parquet_round_trip(self, tmp_path):
@@ -331,43 +324,43 @@ class TestFloatAttribute:
 
 
 def test_attribute_metadata_keys():
-    class Inner1(Table):
-        id = IntAttribute()
+    class Inner1(qv.Table):
+        id = qv.IntAttribute()
 
-    class Inner2(Table):
-        a = StringAttribute()
-        b = StringAttribute()
+    class Inner2(qv.Table):
+        a = qv.StringAttribute()
+        b = qv.StringAttribute()
 
-    class DoubleInner(Table):
-        id = IntAttribute()
+    class DoubleInner(qv.Table):
+        id = qv.IntAttribute()
 
-    class Middle(Table):
-        c = StringAttribute()
+    class Middle(qv.Table):
+        c = qv.StringAttribute()
         inner = DoubleInner.as_column()
 
-    class Outer(Table):
+    class Outer(qv.Table):
         inner1 = Inner1.as_column()
         inner2 = Inner2.as_column()
         middle = Middle.as_column()
-        id = IntAttribute()
+        id = qv.IntAttribute()
 
     have = Outer._attribute_metadata_keys()
     assert have == {"inner1.id", "inner2.a", "inner2.b", "middle.c", "middle.inner.id", "id"}
 
 
 def test_benchmark_int_attribute_access(benchmark):
-    class MyTable(Table):
-        vals = Int64Column()
-        attr = IntAttribute()
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        attr = qv.IntAttribute()
 
     table = MyTable.from_kwargs(vals=[], attr=1)
     benchmark(lambda: table.attr)
 
 
 def test_benchmark_int_attribute_mutation(benchmark):
-    class MyTable(Table):
-        vals = Int64Column()
-        attr = IntAttribute(mutable=True)
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        attr = qv.IntAttribute(mutable=True)
 
     table = MyTable.from_kwargs(vals=[], attr=1)
 
@@ -378,18 +371,18 @@ def test_benchmark_int_attribute_mutation(benchmark):
 
 
 def test_benchmark_str_attribute_access(benchmark):
-    class MyTable(Table):
-        vals = Int64Column()
-        attr = StringAttribute()
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        attr = qv.StringAttribute()
 
     table = MyTable.from_kwargs(vals=[], attr="foo")
     benchmark(lambda: table.attr)
 
 
 def test_benchmark_str_attribute_mutation(benchmark):
-    class MyTable(Table):
-        vals = Int64Column()
-        attr = StringAttribute(mutable=True)
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        attr = qv.StringAttribute(mutable=True)
 
     table = MyTable.from_kwargs(vals=[], attr="foo")
 
@@ -400,18 +393,18 @@ def test_benchmark_str_attribute_mutation(benchmark):
 
 
 def test_benchmark_float_attribute_access(benchmark):
-    class MyTable(Table):
-        vals = Int64Column()
-        attr = FloatAttribute()
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        attr = qv.FloatAttribute()
 
     table = MyTable.from_kwargs(vals=[], attr=1.0)
     benchmark(lambda: table.attr)
 
 
 def test_benchmark_float_attribute_mutation(benchmark):
-    class MyTable(Table):
-        vals = Int64Column()
-        attr = FloatAttribute(mutable=True)
+    class MyTable(qv.Table):
+        vals = qv.Int64Column()
+        attr = qv.FloatAttribute(mutable=True)
 
     table = MyTable.from_kwargs(vals=[], attr=1.0)
 

--- a/test/test_columns.py
+++ b/test/test_columns.py
@@ -8,7 +8,6 @@ import pyarrow as pa
 import pytest
 
 import quivr as qv
-from quivr import errors
 
 current_id = 0
 
@@ -350,7 +349,7 @@ def test_default_values(test_case):
         # Should be an error at class definition time if the default
         # value is an invalid scalar
 
-        with pytest.raises(errors.InvalidColumnDefault):
+        with pytest.raises(qv.InvalidColumnDefault):
 
             class MyTable(qv.Table):
                 col = test_case.column_class(
@@ -365,7 +364,7 @@ def test_default_values(test_case):
         class MyTable2(qv.Table):
             col = test_case.column_class(default=default_value, nullable=False, **test_case.column_kwargs)
 
-        with pytest.raises(errors.InvalidColumnDefault):
+        with pytest.raises(qv.InvalidColumnDefault):
             t = MyTable2.from_data(col=[None])
         return
 

--- a/test/test_concat.py
+++ b/test/test_concat.py
@@ -2,8 +2,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from quivr import errors
-from quivr.concat import concatenate
+import quivr as qv
 
 from .test_tables import Pair, TableWithAttributes, Wrapper
 
@@ -17,7 +16,7 @@ def test_concatenate():
     ys2 = pa.array([44, 55, 66], pa.int64())
     pair2 = Pair.from_arrays([xs2, ys2])
 
-    have = concatenate([pair1, pair2])
+    have = qv.concatenate([pair1, pair2])
     assert len(have) == 6
     np.testing.assert_array_equal(have.x, [1, 2, 3, 11, 22, 33])
 
@@ -35,7 +34,7 @@ def test_concatenate_nested():
     ids2 = pa.array(["v4", "v5", "v6"], pa.string())
     w2 = Wrapper.from_arrays([pairs2, ids2])
 
-    have = concatenate([w1, w2])
+    have = qv.concatenate([w1, w2])
     assert len(have) == 6
     np.testing.assert_array_equal(have.pair.x, [1, 2, 3, 11, 22, 33])
     np.testing.assert_array_equal(have.id, ["v1", "v2", "v3", "v4", "v5", "v6"])
@@ -43,7 +42,7 @@ def test_concatenate_nested():
 
 def test_concatenate_empty():
     with pytest.raises(ValueError, match="No values to concatenate"):
-        concatenate([])
+        qv.concatenate([])
 
 
 @pytest.mark.benchmark(group="ops")
@@ -56,14 +55,12 @@ def test_benchmark_concatenate_100(benchmark):
     ys2 = pa.array([44, 55, 66], pa.int64())
     pair2 = Pair.from_arrays([xs2, ys2])
 
-    benchmark(concatenate, [pair1, pair2] * 50)
+    benchmark(qv.concatenate, [pair1, pair2] * 50)
 
 
 def test_concatenate_different_types():
-    with pytest.raises(
-        errors.TablesNotCompatibleError, match="All tables must be the same class to concatenate"
-    ):
-        concatenate([Pair.empty(), Wrapper.empty()])
+    with pytest.raises(qv.TablesNotCompatibleError, match="All tables must be the same class to concatenate"):
+        qv.concatenate([Pair.empty(), Wrapper.empty()])
 
 
 def test_concatenate_different_attrs():
@@ -71,13 +68,13 @@ def test_concatenate_different_attrs():
     t2 = TableWithAttributes.from_data(x=[3], y=[4], attrib="bar")
 
     with pytest.raises(
-        errors.TablesNotCompatibleError, match="All tables must have the same attribute values to concatenate"
+        qv.TablesNotCompatibleError, match="All tables must have the same attribute values to concatenate"
     ):
-        concatenate([t1, t2])
+        qv.concatenate([t1, t2])
 
 
 def test_concatenate_same_attrs():
     t1 = TableWithAttributes.from_data(x=[1], y=[2], attrib="foo")
     t2 = TableWithAttributes.from_data(x=[3], y=[4], attrib="foo")
-    have = concatenate([t1, t2])
+    have = qv.concatenate([t1, t2])
     assert have.attrib == "foo"

--- a/test/test_defragment.py
+++ b/test/test_defragment.py
@@ -1,8 +1,7 @@
 import pyarrow as pa
 import pytest
 
-from quivr.concat import concatenate
-from quivr.defragment import defragment
+import quivr as qv
 
 from .test_tables import Pair
 
@@ -14,11 +13,11 @@ def test_defragment():
             pa.array([4, 5, 6], pa.int64()),
         ]
     )
-    combined = concatenate([p1] * 10, defrag=False)
+    combined = qv.concatenate([p1] * 10, defrag=False)
     assert len(combined) == 30
     assert len(combined.column("x").chunks) == 10
 
-    defragged = defragment(combined)
+    defragged = qv.defragment(combined)
     assert len(defragged) == 30
     assert len(defragged.column("x").chunks) == 1
 
@@ -33,5 +32,5 @@ def test_benchmark_defragment_100(benchmark):
             pa.array([4, 5, 6], pa.int64()),
         ]
     )
-    combined = concatenate([p1] * 100, defrag=False)
-    benchmark(defragment, combined)
+    combined = qv.concatenate([p1] * 100, defrag=False)
+    benchmark(qv.defragment, combined)

--- a/test/test_query_speed.py
+++ b/test/test_query_speed.py
@@ -3,7 +3,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
-from quivr import Column, Float64Column, Int64Column, StringColumn, Table
+import quivr as qv
 
 try:
     import datafusion
@@ -13,10 +13,10 @@ except ImportError:
 
 
 def new_table(N=1_000_00):
-    class MyTable(Table):
-        x = Float64Column()
-        y = StringColumn()
-        z = Int64Column()
+    class MyTable(qv.Table):
+        x = qv.Float64Column()
+        y = qv.StringColumn()
+        z = qv.Int64Column()
 
     seed = 1234
     np.random.seed(seed)
@@ -101,16 +101,16 @@ def test_sum_if_using_numpy(benchmark):
     benchmark(sumif_numpy, data)
 
 
-class InnerTable(Table):
-    x = Float64Column()
-    y = StringColumn()
-    z = Int64Column()
+class InnerTable(qv.Table):
+    x = qv.Float64Column()
+    y = qv.StringColumn()
+    z = qv.Int64Column()
 
 
-class OuterTable(Table):
-    x = Float64Column()
-    y = StringColumn()
-    z = Int64Column()
+class OuterTable(qv.Table):
+    x = qv.Float64Column()
+    y = qv.StringColumn()
+    z = qv.Int64Column()
     inner = InnerTable.as_column()
 
 
@@ -200,11 +200,11 @@ def test_sum_if_nested_using_numpy(benchmark):
     benchmark(sumif_nested_numpy, data)
 
 
-class TableWithListColumn(Table):
-    x = Float64Column()
-    y = StringColumn()
-    z = Int64Column()
-    covariance = Column(pa.fixed_shape_tensor(pa.float64(), (3, 3)))
+class TableWithListColumn(qv.Table):
+    x = qv.Float64Column()
+    y = qv.StringColumn()
+    z = qv.Int64Column()
+    covariance = qv.Column(pa.fixed_shape_tensor(pa.float64(), (3, 3)))
 
     def cov_matrix(self):
         return self.covariance.combine_chunks().to_numpy_ndarray()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,16 +1,16 @@
 import pyarrow.compute as pc
 
-from quivr import Int64Column, StringColumn, Table
+import quivr as qv
 
 
-class Pair(Table):
-    x = Int64Column()
-    y = Int64Column()
+class Pair(qv.Table):
+    x = qv.Int64Column()
+    y = qv.Int64Column()
 
 
-class Container(Table):
+class Container(qv.Table):
     pair = Pair.as_column()
-    name = StringColumn()
+    name = qv.StringColumn()
 
 
 class TestParquetSerialization:
@@ -56,9 +56,9 @@ class TestParquetSerialization:
         pair = Pair.from_data(x=[1, 2, 3], y=[4, 5, 6])
         pair.to_parquet(path)
 
-        class Pair2(Table):
-            a = Int64Column()
-            b = Int64Column()
+        class Pair2(qv.Table):
+            a = qv.Int64Column()
+            b = qv.Int64Column()
 
         have = Pair2.from_parquet(path, column_name_map={"x": "a", "y": "b"})
         want = Pair2.from_data(a=[1, 2, 3], b=[4, 5, 6])

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -2,13 +2,12 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from quivr import validators
-from quivr.errors import ValidationError
+import quivr as qv
 
 
 def test_eq():
     values = pa.array([1, 1, 1, 1], type=pa.int64())
-    checker = validators.eq(1)
+    checker = qv.eq(1)
     assert checker.valid(values)
     checker.validate(values)
 
@@ -19,13 +18,13 @@ def test_eq():
     assert indices.to_pylist() == [3]
     assert values.to_pylist() == [2]
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(qv.ValidationError):
         checker.validate(values)
 
 
 def test_lt():
     values = pa.array([1, 2, 3, 4], type=pa.int64())
-    checker = validators.lt(5)
+    checker = qv.lt(5)
     assert checker.valid(values)
 
     values = pa.array([1, 2, 3, 5], type=pa.int64())
@@ -38,7 +37,7 @@ def test_lt():
 
 def test_le():
     values = pa.array([1, 2, 3, 4], type=pa.int64())
-    checker = validators.le(4)
+    checker = qv.le(4)
     assert checker.valid(values)
 
     values = pa.array([1, 2, 3, 5], type=pa.int64())
@@ -51,7 +50,7 @@ def test_le():
 
 def test_gt():
     values = pa.array([1, 2, 3, 4], type=pa.int64())
-    checker = validators.gt(0)
+    checker = qv.gt(0)
     assert checker.valid(values)
 
     values = pa.array([1, 2, 3, 0], type=pa.int64())
@@ -64,7 +63,7 @@ def test_gt():
 
 def test_ge():
     values = pa.array([1, 2, 3, 4], type=pa.int64())
-    checker = validators.ge(1)
+    checker = qv.ge(1)
     assert checker.valid(values)
 
     values = pa.array([1, 2, 3, 0], type=pa.int64())
@@ -77,7 +76,7 @@ def test_ge():
 
 def test_is_in():
     values = pa.array(["a", "b", "c", "c"], type=pa.string())
-    checker = validators.is_in(["a", "b", "c"])
+    checker = qv.is_in(["a", "b", "c"])
     assert checker.valid(values)
 
     values = pa.array(["a", "b", "c", "d"], type=pa.string())
@@ -91,17 +90,17 @@ def test_is_in():
 @pytest.mark.benchmark(group="validators")
 def test_benchmark_eq(benchmark):
     values = pa.array(np.ones(1000), type=pa.int64())
-    checker = validators.eq(1)
+    checker = qv.eq(1)
     benchmark(checker.valid, values)
 
 
 def test_validating_with_nulls():
     values = pa.array([1, 1, 1, None], type=pa.int64())
-    checker = validators.eq(1)
+    checker = qv.eq(1)
     checker.validate(values)
 
 
 def test_validate_all_null():
     values = pa.array([None, None, None, None], type=pa.int64())
-    checker = validators.eq(1)
+    checker = qv.eq(1)
     checker.validate(values)

--- a/test/typing_tests/attributes.py
+++ b/test/typing_tests/attributes.py
@@ -1,12 +1,12 @@
 from typing_extensions import assert_type
 
-import quivr
+import quivr as qv
 
 
-class AttribTable(quivr.Table):
-    string_attrib = quivr.StringAttribute()
-    int_attrib = quivr.IntAttribute()
-    float_attrib = quivr.FloatAttribute()
+class AttribTable(qv.Table):
+    string_attrib = qv.StringAttribute()
+    int_attrib = qv.IntAttribute()
+    float_attrib = qv.FloatAttribute()
 
 
 attrib_instance = AttribTable.empty(string_attrib="hello", int_attrib=1, float_attrib=1.0)

--- a/test/typing_tests/columns.py
+++ b/test/typing_tests/columns.py
@@ -1,17 +1,17 @@
 import pyarrow
 from typing_extensions import assert_type
 
-import quivr
+import quivr as qv
 
 
-class Pair(quivr.Table):
-    x = quivr.Float64Column()
+class Pair(qv.Table):
+    x = qv.Float64Column()
 
 
-class MyTable(quivr.Table):
-    string_col = quivr.StringColumn()
-    int8_col = quivr.Int8Column()
-    float64_col = quivr.Float64Column()
+class MyTable(qv.Table):
+    string_col = qv.StringColumn()
+    int8_col = qv.Int8Column()
+    float64_col = qv.Float64Column()
 
     pair_col = Pair.as_column(nullable=True)
 
@@ -26,11 +26,11 @@ assert_type(instance.int8_col, pyarrow.Int8Array)
 assert_type(instance.float64_col, pyarrow.lib.DoubleArray)
 
 # Class-level attributes should be the columns themselves
-assert_type(MyTable.string_col, quivr.StringColumn)
+assert_type(MyTable.string_col, qv.StringColumn)
 
 # Sub-tables should be generics
 assert_type(instance.pair_col, Pair)
-assert_type(MyTable.pair_col, quivr.SubTableColumn[Pair])
+assert_type(MyTable.pair_col, qv.SubTableColumn[Pair])
 
 
 empty_instance = MyTable.empty()

--- a/test/typing_tests/linkages.py
+++ b/test/typing_tests/linkages.py
@@ -1,36 +1,36 @@
 from typing_extensions import assert_type
 
-import quivr
+import quivr as qv
 
 
-class MyLeftTable(quivr.Table):
-    id_col = quivr.Int64Column()
-    x = quivr.Float64Column()
+class MyLeftTable(qv.Table):
+    id_col = qv.Int64Column()
+    x = qv.Float64Column()
 
 
-class MyRightTable(quivr.Table):
-    l_id_col = quivr.Int64Column()
-    y = quivr.Float64Column()
+class MyRightTable(qv.Table):
+    l_id_col = qv.Int64Column()
+    y = qv.Float64Column()
 
 
 left_val = MyLeftTable.from_kwargs(id_col=[1, 2, 3], x=[1.0, 2.0, 3.0])
 
 right_val = MyRightTable.from_kwargs(l_id_col=[1, 2, 3, 4], y=[1.0, 2.0, 3.0, 4.0])
 
-linkage = quivr.Linkage(left_val, right_val, left_val.id_col, right_val.l_id_col)
+linkage = qv.Linkage(left_val, right_val, left_val.id_col, right_val.l_id_col)
 
-assert_type(linkage, quivr.Linkage[MyLeftTable, MyRightTable])
+assert_type(linkage, qv.Linkage[MyLeftTable, MyRightTable])
 
 assert_type(linkage.select_left(2), MyLeftTable)
 assert_type(linkage.select_right(2), MyRightTable)
 
 assert_type(linkage.select(2), tuple[MyLeftTable, MyRightTable])
 
-multi_linkage = quivr.MultiKeyLinkage(
+multi_linkage = qv.MultiKeyLinkage(
     left_val,
     right_val,
     {"id": left_val.id_col, "pos": left_val.x},
     {"id": right_val.l_id_col, "pos": right_val.y},
 )
 
-assert_type(multi_linkage, quivr.MultiKeyLinkage[MyLeftTable, MyRightTable])
+assert_type(multi_linkage, qv.MultiKeyLinkage[MyLeftTable, MyRightTable])


### PR DESCRIPTION
1. Importing modules is much better than importing objects. It permits reloading, makes monkeypatching feasible in tests, and works better with importlib machinery.
2. qv is a tidy abbreviation that is not likely to be used elsewhere.

Using `import quivr as qv` everywhere helps communicate that it's a good pattern.

Fixes #29 