### PR TITLE
Fix nullable subtables

### DIFF
--- a/quivr/__init__.py
+++ b/quivr/__init__.py
@@ -53,7 +53,13 @@ from .errors import (
     ValidationError,
 )
 from .linkage import Linkage, MultiKeyLinkage, combine_linkages, combine_multilinkages
-from .tables import AnyTable, AttributeValueType, DataSourceType, Table, ArrowArrayProvider
+from .tables import (
+    AnyTable,
+    ArrowArrayProvider,
+    AttributeValueType,
+    DataSourceType,
+    Table,
+)
 from .validators import Validator, and_, eq, ge, gt, is_in, le, lt
 
 __all__ = [

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -320,7 +320,8 @@ class Table:
             raise ValueError("No data provided")
 
         for idx in empty_columns:
-            arrays[idx] = pa.nulls(size, type=cls.schema[idx].type)
+            column = getattr(cls, cls.schema[idx].name)
+            arrays[idx] = column._nulls(size)
 
         # Inform the type checker that we've filled all Nones
         arrays = cast(list[pa.Array], arrays)

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -363,7 +363,7 @@ def test_from_kwargs_missing_nullable_subtable():
 
     have = Wrapper.from_kwargs(x=[1, 2, 3])
     assert have.x.null_count == 0
-    assert have.pairs.null_count == 3
+    assert have.pairs.to_structarray().null_count == 3
 
 
 class TableWithAttributes(qv.Table):

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -352,6 +352,20 @@ def test_from_kwargs_no_data():
         NullablePair.from_kwargs()
 
 
+def test_from_kwargs_missing_nullable_subtable():
+    class Pair(qv.Table):
+        x = qv.Int64Column()
+        y = qv.Int64Column()
+
+    class Wrapper(qv.Table):
+        x = qv.Int64Column()
+        pairs = Pair.as_column(nullable=True)
+
+    have = Wrapper.from_kwargs(x=[1, 2, 3])
+    assert have.x.null_count == 0
+    assert have.pairs.null_count == 3
+
+
 class TableWithAttributes(qv.Table):
     x = qv.Int64Column()
     y = qv.Int64Column()

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -363,7 +363,19 @@ def test_from_kwargs_missing_nullable_subtable():
 
     have = Wrapper.from_kwargs(x=[1, 2, 3])
     assert have.x.null_count == 0
-    assert have.pairs.to_structarray().null_count == 3
+    # This isn't exactly what we'd like to see. I'd like it if this
+    # could be written more like "assert have.pairs.null_count ==
+    # 3". But pairs is a quivr.Table, not a pyarrow.Array; it doesn't
+    # have a null count directly. The best we can do is look at the
+    # structs inside.
+    assert have.pairs.x.null_count == 3
+    assert have.pairs.y.null_count == 3
+
+    # This reflects the behavior we'd like to see, but it's not
+    # really the way the API works.
+    have_sa = have.to_structarray()
+    assert have_sa.field("x").null_count == 0
+    assert have_sa.field("pairs").null_count == 3
 
 
 class TableWithAttributes(qv.Table):


### PR DESCRIPTION
Due to https://github.com/apache/arrow/issues/37072, we're unable to call `pa.nulls` on `struct`-typed data safely. This is a hacky workaround - it turns out that `pa.array` does the right thing.

