### PR TITLE
Add method for setting a column's value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ This file documents notable changes between versions of quivr.
 
 ## [Unreleased]
 
-Nothing yet!
+### Added
+
+- `Table.set_column` was added. This is a new method that returns a
+  copy of the table, but with a single column replaced.
+
+### Removed
+
+- Setting columns through normal Python assignment statements
+  (`table.x = ...`) is no longer possible. It was an accident that it
+  worked in the first place. Instead, use `Table.set_column`.
 
 ## [0.6.3] - 2023-08-16
 

--- a/docs/source/api/columns.rst
+++ b/docs/source/api/columns.rst
@@ -22,8 +22,10 @@ The ``Person`` Table defined above has three columns: a string name, a
 uint8 age, and a list of strings for books.
 
 All of the column types below inherit from :class:`Column`, and so
-they are Descriptors: they all have :meth:`Column.__get__`,
-:meth:`Column.__set__`, and :meth:`Column.__set_name__` methods.
+they are Descriptors: they all have :meth:`Column.__get__` and
+:meth:`Column.__set_name__` methods. They do _not_ have a
+``Column.__set__`` attribute. If you want to set a column value on a
+Table instance, use :meth:`Table.set_column`.
 
 
 .. _simple_types:

--- a/docs/source/api/tables.rst
+++ b/docs/source/api/tables.rst
@@ -79,6 +79,7 @@ Miscellaneous
 .. automethod:: Table.__repr__
 .. automethod:: Table.__len__
 .. automethod:: Table.__eq__
+.. automethod:: Table.set_column
 
 Utility Functions
 +++++++++++++++++

--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -91,14 +91,6 @@ class Column:
             return self
         return obj.table.column(self.name)
 
-    def __set__(self, obj: tables.Table, value: pa.Array) -> None:
-        """
-        Sets the data for this column on a Table instance.
-
-        This method is part of the `descriptor protocol <https://docs.python.org/3/howto/descriptor.html>`_.
-        """
-        obj.table = self._set_on_pyarrow_table(obj.table, value)
-
     def __set_name__(self, owner: type, name: str) -> None:
         """
         Sets the name of the column.
@@ -231,9 +223,6 @@ class SubTableColumn(Column, Generic[T]):
 
         table = table.set_column(idx, self.pyarrow_field(), data)
         return table
-
-    def __set__(self, obj: tables.Table, value: T) -> None:
-        obj.table = self._set_on_pyarrow_table(obj.table, value)
 
     @overload
     def __get__(self, obj: None, objtype: type) -> Self:

--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -97,9 +97,7 @@ class Column:
 
         This method is part of the `descriptor protocol <https://docs.python.org/3/howto/descriptor.html>`_.
         """
-        idx = obj.table.schema.get_field_index(self.name)
-        value = self.fill_default(value)
-        obj.table = obj.table.set_column(idx, self.pyarrow_field(), [value])
+        obj.table = self._set_on_pyarrow_table(obj.table, value)
 
     def __set_name__(self, owner: type, name: str) -> None:
         """
@@ -168,6 +166,12 @@ class Column:
         """Return an array of nulls of the appropriate size."""
         return pa.nulls(n, type=self.dtype)
 
+    def _set_on_pyarrow_table(self, table: pa.Table, data: pa.Array) -> pa.Table:
+        """Set the data for this column on a pyarrow Table."""
+        idx = table.schema.get_field_index(self.name)
+        value = self.fill_default(data)
+        return table.set_column(idx, self.pyarrow_field(), [value])
+
 
 T = TypeVar("T", bound=tables.Table)
 
@@ -200,17 +204,21 @@ class SubTableColumn(Column, Generic[T]):
         dtype = pa.struct(self.schema)
         super().__init__(dtype, nullable=nullable, metadata=metadata)
 
-    def __set__(self, obj: tables.Table, value: T) -> None:
+    def _set_on_pyarrow_table(self, table: pa.Table, value: T) -> pa.Table:
+        """Set the data for this column on a pyarrow Table. This
+        includes setting metadata which encodes the subtable's
+        attributes.
+        """
         # Propagate the value's metadata through to the parent
-        metadata = obj.table.schema.metadata
+        metadata = table.schema.metadata
         value_meta = value.table.schema.metadata
         if value_meta is not None:
             for key, val in value_meta.items():
                 key = (self.name + "." + key.decode("utf-8")).encode("utf-8")
                 metadata[key] = val
 
-        idx = obj.table.schema.get_field_index(self.name)
-        obj.table = obj.table.replace_schema_metadata(metadata)
+        idx = table.schema.get_field_index(self.name)
+        table = table.replace_schema_metadata(metadata)
         data = value.to_structarray()
         if self.nullable:
             # rewrite the structarray's type to make all fields
@@ -220,7 +228,12 @@ class SubTableColumn(Column, Generic[T]):
             for field in data.type:
                 fields.append(field.with_nullable(True))
             data = pa.StructArray.from_arrays(data.flatten(), fields=fields)
-        obj.table = obj.table.set_column(idx, self.pyarrow_field(), [data])
+
+        table = table.set_column(idx, self.pyarrow_field(), data)
+        return table
+
+    def __set__(self, obj: tables.Table, value: T) -> None:
+        obj.table = self._set_on_pyarrow_table(obj.table, value)
 
     @overload
     def __get__(self, obj: None, objtype: type) -> Self:

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -77,7 +77,8 @@ class Table:
 
     Table instances are immutable, but can be sliced, filtered,
     sorted, or otherwise manipulated, resulting in new Table
-    instances.
+    instances. In particular, see the :meth:`Table.set_column` method,
+    which returns a copy of the Table with a single column replaced.
 
     :cvar schema: The pyarrow schema for this table.
     :vartype schema: pyarrow.Schema

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -1075,22 +1075,9 @@ class Table:
             return self.set_column(name, subtable_new)
 
         column = self._column_obj(name)
-        idx = self.table.schema.get_field_index(name)
 
         if data is None:
             data = column._nulls(len(self))
 
-        if isinstance(data, Table):
-            data = data.to_structarray()
-
-            if column.nullable:
-                # rewrite the structarray's type to make all fields
-                # nullable. This is necessary for the case where the
-                # field is not-nullable, but the table is nullable.
-                fields = []
-                for field in data.type:
-                    fields.append(field.with_nullable(True))
-                data = pa.StructArray.from_arrays(data.flatten(), fields=fields)
-
-        table = self.table.set_column(idx, column.pyarrow_field(), [data])
+        table = column._set_on_pyarrow_table(self.table, data)
         return self.from_pyarrow(table=table, validate=True, permit_nulls=False)

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -1077,6 +1077,9 @@ class Table:
         column = self._column_obj(name)
         idx = self.table.schema.get_field_index(name)
 
+        if data is None:
+            data = column._nulls(len(self))
+
         if isinstance(data, Table):
             data = data.to_structarray()
 

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -856,3 +856,22 @@ def test_set_column_none():
     assert t.x.equals(pa.array([1, 2, 3], pa.int64()))
     # new table should have new column
     assert t2.x.equals(pa.array([None, None, None], pa.int64()))
+
+
+def test_set_column_changes_subtable_attribute():
+    class Inner(qv.Table):
+        x = qv.Int64Column()
+        name = qv.StringAttribute()
+
+    class Outer(qv.Table):
+        inner = Inner.as_column()
+
+    i = Inner.from_kwargs(x=[1, 2, 3], name="a")
+    o = Outer.from_kwargs(inner=i)
+
+    i2 = Inner.from_kwargs(x=[4, 5, 6], name="b")
+
+    o2 = o.set_column("inner", i2)
+
+    assert o2.inner.x.equals(pa.array([4, 5, 6], pa.int64()))
+    assert o2.inner.name == "b"

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -842,3 +842,17 @@ def test_set_column_null():
     assert t.x.equals(pa.array([1, 2, 3], pa.int64()))
     # new table should have new column
     assert t2.x.equals(pa.array([None, None, None], pa.int64()))
+
+
+def test_set_column_none():
+    class PairWithNulls(qv.Table):
+        x = qv.Int64Column(nullable=True)
+        y = qv.Int64Column(nullable=True)
+
+    t = PairWithNulls.from_kwargs(x=[1, 2, 3], y=[4, 5, 6])
+    t2 = t.set_column("x", None)
+
+    # original should be unchanged
+    assert t.x.equals(pa.array([1, 2, 3], pa.int64()))
+    # new table should have new column
+    assert t2.x.equals(pa.array([None, None, None], pa.int64()))

--- a/test/test_tables.py
+++ b/test/test_tables.py
@@ -776,3 +776,69 @@ def test_no_forbidden_column_names():
 
         class T5(qv.Table):
             _column_validators = qv.StringColumn()
+
+
+def test_set_column():
+    t = Pair.from_kwargs(x=[1, 2, 3], y=[4, 5, 6])
+    t2 = t.set_column("x", [7, 8, 9])
+
+    # original should be unchanged
+    assert t.x.equals(pa.array([1, 2, 3], pa.int64()))
+    # new table should have new column
+    assert t2.x.equals(pa.array([7, 8, 9], pa.int64()))
+
+
+def test_set_column_nested():
+    w = Wrapper.from_kwargs(id=["a", "b", "c"], pair=Pair.from_kwargs(x=[1, 2, 3], y=[4, 5, 6]))
+    w2 = w.set_column("pair.x", [7, 8, 9])
+
+    # original should be unchanged
+    assert w.pair.x.equals(pa.array([1, 2, 3], pa.int64()))
+    # new table should have new column
+    assert w2.pair.x.equals(pa.array([7, 8, 9], pa.int64()))
+
+
+def test_set_column_nested_doubly():
+    class DoublyNested(qv.Table):
+        inner = Wrapper.as_column()
+
+    dn = DoublyNested.from_kwargs(
+        inner=Wrapper.from_kwargs(id=["a", "b", "c"], pair=Pair.from_kwargs(x=[1, 2, 3], y=[4, 5, 6]))
+    )
+    dn2 = dn.set_column("inner.pair.x", [7, 8, 9])
+
+    # original should be unchanged
+    assert dn.inner.pair.x.equals(pa.array([1, 2, 3], pa.int64()))
+    # new table should have new column
+    assert dn2.inner.pair.x.equals(pa.array([7, 8, 9], pa.int64()))
+
+    dn3 = dn.set_column("inner.pair", Pair.from_kwargs(x=[7, 8, 9], y=[10, 11, 12]))
+    assert dn3.inner.pair.x.equals(pa.array([7, 8, 9], pa.int64()))
+    assert dn3.inner.pair.y.equals(pa.array([10, 11, 12], pa.int64()))
+
+
+def test_set_column_subtable():
+    w = Wrapper.from_kwargs(id=["a", "b", "c"], pair=Pair.from_kwargs(x=[1, 2, 3], y=[4, 5, 6]))
+    w2 = w.set_column("pair", Pair.from_kwargs(x=[7, 8, 9], y=[10, 11, 12]))
+
+    # original should be unchanged
+    assert w.pair.x.equals(pa.array([1, 2, 3], pa.int64()))
+    assert w.pair.y.equals(pa.array([4, 5, 6], pa.int64()))
+
+    # new table should have new column
+    assert w2.pair.x.equals(pa.array([7, 8, 9], pa.int64()))
+    assert w2.pair.y.equals(pa.array([10, 11, 12], pa.int64()))
+
+
+def test_set_column_null():
+    class PairWithNulls(qv.Table):
+        x = qv.Int64Column(nullable=True)
+        y = qv.Int64Column(nullable=True)
+
+    t = PairWithNulls.from_kwargs(x=[1, 2, 3], y=[4, 5, 6])
+    t2 = t.set_column("x", pa.nulls(3, pa.int64()))
+
+    # original should be unchanged
+    assert t.x.equals(pa.array([1, 2, 3], pa.int64()))
+    # new table should have new column
+    assert t2.x.equals(pa.array([None, None, None], pa.int64()))


### PR DESCRIPTION
This was previously possible through direct access, but this is a lot clearer and cleaner. It makes it much more obvious that this happens as a copy, not in-place.

TODO:
 - [x] Write docs
 - [x] Update changelog
 - [x] Revisit how `Column.__set__` is implemented, possibly discarding it entirely