### PR TITLE
Add Table.parallel_apply

### DIFF
--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -1090,7 +1090,7 @@ class Table:
         self,
         func: Callable[[Self], T],
         chunk_size: int = 10000,
-            max_workers: Optional[int] = None,
+        max_workers: Optional[int] = None,
     ) -> Iterator[T]:
         """Call func on self's data in parallel.
 

--- a/test/test_parallel_apply.py
+++ b/test/test_parallel_apply.py
@@ -1,0 +1,124 @@
+import numpy as np
+
+import quivr as qv
+
+
+class Pair(qv.Table):
+    x = qv.Float64Column()
+    y = qv.Float64Column()
+
+    def pairwise_product(self):
+        return self.x.to_numpy() * self.y.to_numpy()
+
+    def min_pairwise_product(self):
+        return self.pairwise_product().min()
+
+
+def test_parallel_apply_closure():
+    ps = Pair.from_kwargs(
+        x=np.arange(10000, dtype=np.float64),
+        y=np.arange(10000, dtype=np.float64),
+    )
+
+    enclosed = 2
+
+    def multiply(p):
+        return p.min_pairwise_product() * enclosed
+
+    results = ps.parallel_apply(
+        multiply,
+        chunk_size=1000,
+    )
+
+    results = list(sorted(results))
+    assert len(results) == 10
+    assert results[0] == 0
+    assert results[1] == 1000 * 1000 * 2
+    assert results[2] == 2000 * 2000 * 2
+    assert results[3] == 3000 * 3000 * 2
+    assert results[4] == 4000 * 4000 * 2
+    assert results[5] == 5000 * 5000 * 2
+    assert results[6] == 6000 * 6000 * 2
+    assert results[7] == 7000 * 7000 * 2
+    assert results[8] == 8000 * 8000 * 2
+    assert results[9] == 9000 * 9000 * 2
+
+
+def test_parallel_apply_lambda():
+    ps = Pair.from_kwargs(
+        x=np.arange(10000, dtype=np.float64),
+        y=np.arange(10000, dtype=np.float64),
+    )
+
+    results = ps.parallel_apply(
+        lambda p: p.min_pairwise_product(),
+        chunk_size=1000,
+    )
+    results = list(sorted(results))
+    assert len(results) == 10
+    assert results[0] == 0
+    assert results[1] == 1000 * 1000
+    assert results[2] == 2000 * 2000
+    assert results[3] == 3000 * 3000
+    assert results[4] == 4000 * 4000
+    assert results[5] == 5000 * 5000
+    assert results[6] == 6000 * 6000
+    assert results[7] == 7000 * 7000
+    assert results[8] == 8000 * 8000
+    assert results[9] == 9000 * 9000
+
+
+def test_parallel_apply_method():
+    ps = Pair.from_kwargs(
+        x=np.arange(10000, dtype=np.float64),
+        y=np.arange(10000, dtype=np.float64),
+    )
+
+    results = ps.parallel_apply(
+        Pair.min_pairwise_product,
+        chunk_size=1000,
+    )
+    results = list(sorted(results))
+    assert len(results) == 10
+    assert results[0] == 0
+    assert results[1] == 1000 * 1000
+    assert results[2] == 2000 * 2000
+    assert results[3] == 3000 * 3000
+    assert results[4] == 4000 * 4000
+    assert results[5] == 5000 * 5000
+    assert results[6] == 6000 * 6000
+    assert results[7] == 7000 * 7000
+    assert results[8] == 8000 * 8000
+    assert results[9] == 9000 * 9000
+
+
+class TableWithAttribute(qv.Table):
+    x = qv.Float64Column()
+    y = qv.Float64Column()
+
+    name = qv.StringAttribute()
+
+
+class Wrapper(qv.Table):
+    twa = TableWithAttribute.as_column()
+    id = qv.StringAttribute()
+
+
+def test_parallel_apply_attributes():
+    twa = TableWithAttribute.from_kwargs(
+        x=np.arange(10000, dtype=np.float64),
+        y=np.arange(10000, dtype=np.float64),
+        name="foo",
+    )
+    w = Wrapper.from_kwargs(
+        twa=twa,
+        id="bar",
+    )
+
+    results = w.parallel_apply(
+        lambda p: p.twa.name,
+        chunk_size=1000,
+    )
+    results = list(results)
+    assert len(results) == 10
+    assert all(r == "foo" for r in results)


### PR DESCRIPTION
This is a minimalist, simple implementation of multithreaded computation on a quivr Table. 

The Table is sliced using RecordBatches, which don't require a copy. Each thread gets a slice. The threads work on their chunk and yield back arbitrary data which gets fed out as an iterator.

The test shows how it can be used. You can apply a function, a lambda, a closure, or a method - they'll all work.

I have not yet benchmarked this, but I have done very rudimentary checks on memory usage (like, squint at `top`) and think it doesn't do anything too silly.