### PR TITLE
Add experimental shmem-based parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,26 @@ This file documents notable changes between versions of quivr.
 
 ## [Unreleased]
 
-Nothing yet!
+### Added
+
+`quivr.experimental.shmem` provides new utilities for run functions
+against quivr Tables with multiple processes in shared memory:
+
+ - `to_shared_memory` and `from_shared_memory` can be used to read and
+   write a quivr Table in shared memory. This allows separate
+   processes to work off of slices of a Table without a copy of any
+   data, or with redundant memory usage.
+ - `execute_parallel` is a function that simplifies running a function
+   against a Table's data with multiple processes. The Table's data
+   will be split up using a configurable partitioning strategy, and
+   each partition will be passed to a separate worker. Results are
+   returned as they are completed in a streaming iterator.
+ - `ChunkedPartitioning` and `GroupedPartitioning` are classes which
+   represent two possible partitioning strategies: uniform chunks of
+   fixed size, or partitions which share a common particular
+   value. Additional partitioning strategies can be provided by
+   providing a subclass implementation of the `Partitioning` class.
+
 
 ## [0.6.5] - 2023-08-30
 

--- a/quivr/experimental/shmem.py
+++ b/quivr/experimental/shmem.py
@@ -132,7 +132,7 @@ def execute_parallel(
     func: Callable[[T], Any],
     max_workers: int = 4,
     partitioning: Partitioning = ChunkedPartitioning(chunk_size=1000),
-) -> list[Any]:
+) -> Iterator[Any]:
     """
     Execute a function in parallel on a Table.
 
@@ -169,9 +169,5 @@ def execute_parallel(
                 futures.append(future)
 
             # Wait for the results
-            results = []
-            for future in futures:
-                results.append(future.result())
-
-    # Return the results
-    return results
+            for future in concurrent.futures.as_completed(futures):
+                yield future.result()

--- a/quivr/experimental/shmem.py
+++ b/quivr/experimental/shmem.py
@@ -1,0 +1,177 @@
+import abc
+import concurrent.futures
+import mmap
+from multiprocessing import managers, shared_memory
+from typing import Any, Callable, Iterator, TypeVar
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+import quivr as qv
+
+
+def to_shared_memory(data: qv.Table, mgr: managers.SharedMemoryManager) -> shared_memory.SharedMemory:
+    """
+    Write a quivr Table instance to a new shared memory object owned by a SharedMemoryManager.
+
+    :param data: The quivr Table instance to write.
+    :param mgr: The SharedMemoryManager to own the shared memory object.
+    :return: The shared memory object.
+    """
+
+    # Write the data as record batches to a buffer
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, data.table.schema) as writer:
+        writer.write_table(data.table)
+    buf = sink.getvalue()
+
+    shm = mgr.SharedMemory(size=buf.size)
+    shm.buf[: buf.size] = buf.to_pybytes()
+
+    return shm
+
+
+T = TypeVar("T", bound=qv.Table)
+
+
+def from_shared_memory(shm: shared_memory.SharedMemory, table_class: type[T]) -> T:
+    """
+    Load a shared memory object as a quivr Table instance.
+
+    :param shm: The shared memory object containing a quivr Table,
+        serialized using PyArrow's IPC stream serialization.
+    :param table_class: The class of the Table instance to create.
+    """
+    # HACK: shm.buf.obj is a mmap object, so why not just use that?
+    # Because mmap objects use reference counting internally, and the
+    # shm.buf.obj mmap's reference count will incorrectly require a
+    # ton of management from the caller to avoid leaking
+    # memory. Creating a new mmap here ensures that we'll get the
+    # reference counting right, even though it's pretty ugly.
+    f = mmap.mmap(shm._fd, shm.size)  # type: ignore
+    with pa.ipc.open_stream(f) as reader:
+        pyarrow_table = reader.read_all()
+        instance = table_class.from_pyarrow(pyarrow_table)
+    return instance
+
+
+def _run_on_shared_memory(shm_name: str, table_class: type[T], func: Callable[[T], Any]) -> Any:
+    """
+    Run a function on a table stored in shared memory.
+    """
+
+    # Create a shared memory object
+    shm = shared_memory.SharedMemory(name=shm_name)
+
+    # Run the function
+    instance = from_shared_memory(shm, table_class)
+    return func(instance)
+
+
+class Partitioning(abc.ABC):
+    """
+    A partitioning strategy for executing a function in parallel on a Table.
+
+    This class is abstract and should be subclassed to implement a particular partitioning strategy.
+    """
+
+    @abc.abstractmethod
+    def partition(self, table: T) -> Iterator[T]:
+        ...
+
+
+def partition_func(f: Callable[[T], Iterator[T]]) -> Partitioning:
+    """
+    Defines a partitioning strategy by providing a function that partitions a
+    Table into multiple Tables.
+    """
+
+    class PartitioningFunc(Partitioning):
+        def partition(self, table: T) -> Iterator[T]:
+            return f(table)
+
+    return PartitioningFunc()
+
+
+class ChunkedPartitioning(Partitioning):
+    """
+    Partition a Table into chunks of a given fixed size.
+
+    :param chunk_size: The size of each chunk.
+    """
+
+    def __init__(self, chunk_size: int):
+        self.chunk_size = chunk_size
+
+    def partition(self, table: T) -> Iterator[T]:
+        """
+        Partition a Table into chunks of the given fixed size.
+        """
+        for i in range(0, len(table), self.chunk_size):
+            yield table[i : i + self.chunk_size]
+
+
+class GroupedPartitioning(Partitioning):
+    """
+    Partition a Table into groups based on the unique values in a given column.
+
+    :param group_column: The name of the column to group by.
+    """
+
+    def __init__(self, group_column: str):
+        self.group_column = group_column
+
+    def partition(self, table: T) -> Iterator[T]:
+        for group in table.column(self.group_column).unique():
+            mask = pc.equal(table.column(self.group_column), group)
+            yield table.apply_mask(mask)
+
+
+def execute_parallel(
+    table: T,
+    func: Callable[[T], Any],
+    max_workers: int = 4,
+    partitioning: Partitioning = ChunkedPartitioning(chunk_size=1000),
+) -> list[Any]:
+    """
+    Execute a function in parallel on a Table.
+
+    This function partitions the Table into multiple Tables, and executes the function
+    on each partition in parallel. The results are returned as a Python list.
+
+    :param table: The Table to execute the function on.
+    :param func: The function to execute.
+    :param max_workers: The maximum number of workers to use.
+    :param partitioning: The partitioning strategy to use. The default is to partition
+        the Table into chunks of 1000 rows. The partitioning's ``partition`` method
+        will be called with the Table as its only argument, and the values from the
+        iterator will be fed to a worker pool one-by-one.
+    """
+
+    # Create a pool of workers
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+        # Create a shared memory object
+        with managers.SharedMemoryManager() as mgr:
+            partitions = []
+            for partition in partitioning.partition(table):
+                shm = to_shared_memory(partition, mgr)
+                partitions.append(shm)
+
+            # Execute the function in parallel
+            futures = []
+            for shm in partitions:
+                future = executor.submit(
+                    _run_on_shared_memory,
+                    shm.name,
+                    table.__class__,
+                    func,
+                )
+                futures.append(future)
+
+            # Wait for the results
+            results = []
+            for future in futures:
+                results.append(future.result())
+
+    # Return the results
+    return results

--- a/quivr/experimental/shmem.py
+++ b/quivr/experimental/shmem.py
@@ -4,17 +4,15 @@ import abc
 import concurrent.futures
 import dataclasses
 import mmap
+import sys
 from multiprocessing import managers, shared_memory
-from typing import (
-    Any,
-    Callable,
-    Concatenate,
-    Generic,
-    Iterator,
-    ParamSpec,
-    Self,
-    TypeVar,
-)
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
+from typing import Any, Callable, Concatenate, Generic, Iterator, ParamSpec, TypeVar
 
 import pyarrow as pa
 import pyarrow.compute as pc

--- a/test/test_experimental_shmem.py
+++ b/test/test_experimental_shmem.py
@@ -142,7 +142,11 @@ def test_execute_parallel_extra_args():
     partitioning = qv_shmem.ChunkedPartitioning(chunk_size=2)
 
     results_iter = qv_shmem.execute_parallel(
-        pairs, multiply_by_n, partitioning=partitioning, max_workers=2, args=[2.0]
+        pairs,
+        multiply_by_n,
+        2.0,
+        partitioning=partitioning,
+        max_workers=2,
     )
     results_list = list(results_iter)
 
@@ -165,9 +169,9 @@ def test_execute_parallel_extra_kwargs():
     results_iter = qv_shmem.execute_parallel(
         pairs,
         multiply_by_n,
+        n=2.0,
         partitioning=partitioning,
         max_workers=2,
-        kwargs={"n": 2.0},
     )
     results_list = list(results_iter)
 
@@ -267,9 +271,9 @@ def test_share_auxiliary_table():
     results_iter = qv_shmem.execute_parallel(
         pairs,
         min_pair,
+        pairs2,
         partitioning=partitioning,
         max_workers=2,
-        args=[pairs2],
     )
     results_list = list(results_iter)
 
@@ -286,9 +290,9 @@ def test_share_auxiliary_table():
     results_iter = qv_shmem.execute_parallel(
         pairs,
         min_pair,
+        p2=pairs2,
         partitioning=partitioning,
         max_workers=2,
-        kwargs={"p2": pairs2},
     )
 
     sorted_results_2 = sorted(list(results_iter), key=lambda p: p.x[0].as_py())

--- a/test/test_experimental_shmem.py
+++ b/test/test_experimental_shmem.py
@@ -1,0 +1,120 @@
+import quivr as qv
+from quivr.experimental import shmem as qv_shmem
+
+
+class Pair(qv.Table):
+    x = qv.Float64Column()
+    y = qv.Float64Column()
+
+    def pairwise_min(self):
+        return (self.x.to_numpy() * self.y.to_numpy()).min()
+
+
+class NamedPair(qv.Table):
+    x = qv.Float64Column()
+    y = qv.Float64Column()
+    name = qv.StringAttribute()
+
+    def pairwise_min(self):
+        return (self.x.to_numpy() * self.y.to_numpy()).min()
+
+    def name_is_foo(self):
+        return self.name == "foo"
+
+
+class Wrapper(qv.Table):
+    pair = Pair.as_column()
+    id = qv.Int64Column()
+
+    def pairwise_min(self):
+        return self.pair.pairwise_min()
+
+
+class NamedWrapper(qv.Table):
+    pair = NamedPair.as_column()
+    id = qv.Int64Column()
+
+    def pairwise_min(self):
+        return self.pair.pairwise_min()
+
+    def name_is_foo(self):
+        return self.pair.name_is_foo()
+
+
+def test_execute_parallel_method():
+    pairs = Pair.from_kwargs(
+        x=[1, 2, 3, 4, 5, 6, 7, 8],
+        y=[8, 7, 6, 5, 4, 3, 2, 1],
+    )
+    partitioning = qv_shmem.ChunkedPartitioning(chunk_size=2)
+
+    results_iter = qv_shmem.execute_parallel(
+        pairs, Pair.pairwise_min, partitioning=partitioning, max_workers=2
+    )
+    results_list = list(results_iter)
+
+    assert len(results_list) == 4
+    sorted_results = sorted(results_list)
+    assert sorted_results == [8.0, 8.0, 18.0, 18.0]
+
+
+def test_execute_parallel_nested_table():
+    pairs = Pair.from_kwargs(
+        x=[1, 2, 3, 4, 5, 6, 7, 8],
+        y=[8, 7, 6, 5, 4, 3, 2, 1],
+    )
+    wrapper = Wrapper.from_kwargs(
+        pair=pairs,
+        id=[1, 2, 3, 4, 5, 6, 7, 8],
+    )
+    partitioning = qv_shmem.ChunkedPartitioning(chunk_size=2)
+
+    results_iter = qv_shmem.execute_parallel(
+        wrapper, Wrapper.pairwise_min, partitioning=partitioning, max_workers=2
+    )
+    results_list = list(results_iter)
+
+    assert len(results_list) == 4
+    sorted_results = sorted(results_list)
+    assert sorted_results == [8.0, 8.0, 18.0, 18.0]
+
+
+def test_execute_parallel_attributes():
+    pairs = NamedPair.from_kwargs(
+        x=[1, 2, 3, 4, 5, 6, 7, 8],
+        y=[8, 7, 6, 5, 4, 3, 2, 1],
+        name="foo",
+    )
+    partitioning = qv_shmem.ChunkedPartitioning(chunk_size=2)
+
+    results_iter = qv_shmem.execute_parallel(
+        pairs, NamedPair.name_is_foo, partitioning=partitioning, max_workers=2
+    )
+    results_list = list(results_iter)
+
+    assert len(results_list) == 4
+    sorted_results = sorted(results_list)
+    assert sorted_results == [True, True, True, True]
+
+
+def test_execute_parallel_nested_attributes():
+    pairs = NamedPair.from_kwargs(
+        x=[1, 2, 3, 4, 5, 6, 7, 8],
+        y=[8, 7, 6, 5, 4, 3, 2, 1],
+        name="foo",
+    )
+    wrapper = NamedWrapper.from_kwargs(
+        pair=pairs,
+        id=[1, 2, 3, 4, 5, 6, 7, 8],
+    )
+
+    partitioning = qv_shmem.ChunkedPartitioning(chunk_size=2)
+
+    results_iter = qv_shmem.execute_parallel(
+        wrapper, NamedWrapper.name_is_foo, partitioning=partitioning, max_workers=2
+    )
+    results_list = list(results_iter)
+
+    assert len(results_list) == 4
+    sorted_results = sorted(results_list)
+    assert sorted_results == [True, True, True, True]


### PR DESCRIPTION
This is a parallelism approach that eludes the GIL. It's less tidy and simple than the thread-based parallelism in #49, but if the function being applied has to do work in Python-space, this will be more efficient.

Needs tests, of course.