### PR TITLE
Failing test for filtered table

### DIFF
--- a/test/test_filtered_chunks.py
+++ b/test/test_filtered_chunks.py
@@ -1,0 +1,16 @@
+import pyarrow as pa
+import quivr as qv
+
+
+def test_fast_combine_chunks_masked_array():
+    # Create a ChunkedArray with entirely masked values
+    class MyTable(qv.Table):
+        col = qv.Int64Column()
+
+    table = MyTable.from_kwargs(col=[1, 2, 3, 4, 5])
+    filtered = table.table.filter(pa.array([False, False, False, False, False]))
+    filtered_quivr = MyTable(filtered)
+    # This works
+    assert filtered_quivr.column("col").to_pylist() == []
+    # This fails due to something with _fast_combine_chunks
+    assert filtered_quivr.col.to_pylist() == []


### PR DESCRIPTION
It looks like the `_fast_combine_chunks` needs some kind of additional logic. I noticed this behavior failing in ADAM ETL after updating quivr in our skymapper pipeline.