### PR TITLE
Correct issues in pyarrow type inference  loading from flat dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ This file documents notable changes between versions of quivr.
 
 ## Unreleased
 
-Nothing yet!
+### Fixed
+
+- Quivr tables will now round-trip correctly with all
+  types. Previously, FixedLengthLists, LargeStrings, LargeBinary, and
+  other unusual types could be incorrectly handled when loading from
+  flattened dataframes (#58).
 
 ## [0.7.0] - 2023-10-03
 

--- a/quivr/_arrow_utils.py
+++ b/quivr/_arrow_utils.py
@@ -1,0 +1,23 @@
+from collections.abc import Sequence
+from typing import Any
+
+import pyarrow as pa
+
+
+def build_struct_array(data: Sequence[Any], fields: list[pa.Field]) -> pa.StructArray:
+    """
+    Cast a sequence of pandas Series into a StructArray using a given list of fields.
+
+    The fields must be in the same order as the Series in the sequence.
+
+    See also: https://github.com/apache/arrow/issues/35622
+    """
+    arrays = []
+    for i, (s, f) in enumerate(zip(data, fields)):
+        if isinstance(s, pa.Array):
+            arrays.append(s)
+            continue
+
+        arrays.append(pa.array(s, type=f.type))
+
+    return pa.StructArray.from_arrays(arrays, fields=fields)

--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -1193,11 +1193,10 @@ class NullColumn(Column):
 
     def __init__(
         self,
-        nullable: bool = False,
         metadata: Optional[MetadataDict] = None,
         validator: Optional[validators.Validator] = None,
     ):
-        super().__init__(pa.null(), nullable=nullable, metadata=metadata, validator=validator)
+        super().__init__(pa.null(), nullable=True, metadata=metadata, validator=validator)
 
     @overload
     def __get__(self, obj: None, objtype: type) -> Self:

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -35,6 +35,7 @@ import pyarrow.csv
 import pyarrow.feather
 import pyarrow.parquet
 
+from . import _arrow_utils
 from . import attributes as attr_module
 from . import columns, errors, schemagraph, validators
 
@@ -582,7 +583,7 @@ class Table:
                     arrays.append(struct_arrays[sa_key])
                 else:
                     arrays.append(field_df[subfield.name])
-            sa = pa.StructArray.from_arrays(arrays, fields=list(field.type))
+            sa = _arrow_utils.build_struct_array(arrays, list(field.type))
             struct_arrays[df_key] = sa
 
             # Clean the fields out
@@ -769,7 +770,7 @@ class Table:
         table = self.table
         if flatten:
             table = self.flattened_table()
-        df: pd.DataFrame = table.to_pandas()
+        df: pd.DataFrame = table.to_pandas(date_as_object=False, timestamp_as_object=False)
         if attr_handling == "drop":
             return df
         elif attr_handling == "add_columns":


### PR DESCRIPTION
Pyarrow has special handling for constructing a StructArray which we use when building a Table from a flattened DataFrame. That code path attempts to infer types, which can conflict with the types specifies in the table's schema. This issue has been reported in https://github.com/apache/arrow/issues/38026, but this is a workaround for our purposes.