### PR TITLE
Handle ChunkedArrays as a special case when loading data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This file documents notable changes between versions of quivr.
 
 ## Unreleased
 
-Nothing yet!
+### Fixed
+
+- Loading Table data from pyarrow ChunkedArrays (like with
+  from_kwargs) is now less buggy and faster (#59)
 
 ## [0.7.1] - 2023-10-05
 

--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -151,7 +151,8 @@ class Column:
                 return None
 
             return self._nulls(size_hint)
-
+        if isinstance(data, pa.ChunkedArray) or isinstance(data, pa.Array):
+            return data.cast(self.dtype)
         return pa.array(data, type=self.dtype)
 
     def _nulls(self, n: int) -> pa.Array:


### PR DESCRIPTION
Pyarrow ChunkedArrays do not seem to get properly handled by the pa.array constructor. They get treated as a pure-Python sequence, and iterated over, which gives results which are both buggy and slow.

Instead, accept ChunkedArrays directly, and just try to cast them.